### PR TITLE
Prepared statements support

### DIFF
--- a/acsylla/__init__.py
+++ b/acsylla/__init__.py
@@ -1,7 +1,7 @@
 from acsylla._cython.cyacsylla import (
     Cluster,
-    Statement
+    create_statement
 )
 from . import errors
 
-__all__ = ("Cluster", "Statement", "errors")
+__all__ = ("Cluster", "create_statement", "errors")

--- a/acsylla/_cython/callback_wrapper.pxd
+++ b/acsylla/_cython/callback_wrapper.pxd
@@ -1,11 +1,8 @@
 cdef class CallbackWrapper:
     cdef:
-        CassFuture* cass_future
         object future
 
     cdef void set_result(self)
 
     @staticmethod
     cdef CallbackWrapper new_(CassFuture* cass_future, object loop)
-
-    

--- a/acsylla/_cython/callback_wrapper.pyx
+++ b/acsylla/_cython/callback_wrapper.pyx
@@ -1,51 +1,14 @@
-CASS_ERROR_SYNTAX_ERROR = 2 << 24 | 0x2000
-
-
-class CallbackError(Exception):
-    """ Generic exception used for storing the error number that
-    generated the callback error.
-
-    Later on upper layers can create their own ad-hoc Exceptions
-    for making the error less generics.
-    """
-    def __init__(self, object cass_error):
-        self.cass_error = cass_error
-
-
 cdef class CallbackWrapper:
-
-    def __cinit__(self):
-        self.cass_future = NULL
-
-    def __dealloc__(self):
-        cass_future_free(self.cass_future)
 
     async def __await__(self):
         result = await self.future
         return result
     
     cdef void set_result(self):
-        cdef const CassErrorResult* error_result
-        cdef CassError error
-        cdef const CassResult* cass_result = NULL
-        cdef Result result
-
         if self.future.done():
             return
 
-        error_result = cass_future_get_error_result(self.cass_future)
-        if error_result == NULL: 
-            cass_result = cass_future_get_result(self.cass_future)
-            if cass_result != NULL:
-                result = Result.new_(cass_result)
-                self.future.set_result(result)
-            else:
-                self.future.set_result(None)
-            return
-
-        error = cass_error_result_code(error_result)
-        cass_error_result_free(error_result)
-        self.future.set_exception(CallbackError(error))
+        self.future.set_result(None)
 
     @staticmethod
     cdef CallbackWrapper new_(CassFuture* cass_future, object loop):
@@ -53,10 +16,9 @@ cdef class CallbackWrapper:
 
         cb_wrapper = CallbackWrapper()
         cb_wrapper.future = loop.create_future()
-        cb_wrapper.cass_future = cass_future
 
         error = cass_future_set_callback(
-            cb_wrapper.cass_future,
+            cass_future,
             cb_cass_future,
             <void*> cb_wrapper
         ) 

--- a/acsylla/_cython/cass_errors.pyx
+++ b/acsylla/_cython/cass_errors.pyx
@@ -9,3 +9,13 @@ class CassExceptionSyntaxError(CassException):
     def __init__(self, statment):
         self.statment = statment
         super().__init__(self)
+
+
+class CassExceptionInvalidQuery(CassException):
+    """ Raised when a statment presented an invalid query,
+    for example using an invalid type.
+    """
+
+    def __init__(self, statment):
+        self.statment = statment
+        super().__init__(self)

--- a/acsylla/_cython/cpp_cassandra.pxi
+++ b/acsylla/_cython/cpp_cassandra.pxi
@@ -8,7 +8,11 @@ cdef extern from "cassandra.h":
     cass_true = 1
 
   ctypedef enum CassError:
-    CASS_OK
+    CASS_OK = 0
+    CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS = 16777227
+    CASS_ERROR_SERVER_SYNTAX_ERROR = 33562624
+    CASS_ERROR_SERVER_INVALID_QUERY = 33563136
+    
 
   ctypedef enum CassProtocolVersion:
     CASS_PROTOCOL_VERSION_V1 = 1
@@ -24,6 +28,9 @@ cdef extern from "cassandra.h":
     pass
 
   ctypedef struct CassFuture:
+    pass
+
+  ctypedef struct CassPrepared:
     pass
 
   ctypedef struct CassStatement:
@@ -57,6 +64,7 @@ cdef extern from "cassandra.h":
   CassFuture* cass_session_connect(CassSession* session, const CassCluster* cluster)
   CassFuture* cass_session_connect_keyspace_n(CassSession* session,const CassCluster* cluster, const char* keyspace, size_t keyspace_length)
   CassFuture* cass_session_execute(CassSession * session, const CassStatement* statement)
+  CassFuture* cass_session_prepare_n(CassSession* session, const char* query, size_t query_length);
   CassFuture* cass_session_close(CassSession* session)
 
   CassStatement* cass_statement_new_n(const char* query, size_t query_length, size_t parameter_count)
@@ -69,10 +77,12 @@ cdef extern from "cassandra.h":
   void cass_statement_free(CassStatement* statement)
 
   void cass_future_free(CassFuture* future)
+  CassError cass_future_error_code(CassFuture* future);
   CassError cass_future_set_callback(CassFuture* future, CassFutureCallback callback, void* data)
   CassErrorResult* cass_future_get_error_result(CassFuture* future)
   CassResult* cass_future_get_result(CassFuture* future)
-  
+  const CassPrepared* cass_future_get_prepared(CassFuture* future);
+ 
   CassError cass_error_result_code(CassErrorResult* error_result)
   void cass_error_result_free(CassErrorResult* error_result)
 
@@ -89,3 +99,6 @@ cdef extern from "cassandra.h":
   CassRow* cass_iterator_get_row(const CassIterator* iterator)
   cass_bool_t cass_iterator_next(CassIterator* iterator)
   void cass_iterator_free(CassIterator* iterator)
+
+  CassStatement* cass_prepared_bind(const CassPrepared* prepared);
+  void cass_prepared_free(const CassPrepared* prepared);

--- a/acsylla/_cython/cpp_cassandra.pxi
+++ b/acsylla/_cython/cpp_cassandra.pxi
@@ -8,10 +8,11 @@ cdef extern from "cassandra.h":
     cass_true = 1
 
   ctypedef enum CassError:
-    CASS_OK = 0
-    CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS = 16777227
-    CASS_ERROR_SERVER_SYNTAX_ERROR = 33562624
-    CASS_ERROR_SERVER_INVALID_QUERY = 33563136
+    CASS_OK
+    CASS_ERROR_LIB_NAME_DOES_NOT_EXIST
+    CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS
+    CASS_ERROR_SERVER_SYNTAX_ERROR
+    CASS_ERROR_SERVER_INVALID_QUERY
     
 
   ctypedef enum CassProtocolVersion:
@@ -74,6 +75,14 @@ cdef extern from "cassandra.h":
   CassError cass_statement_bind_bool(CassStatement* statement, size_t index, cass_bool_t value)
   CassError cass_statement_bind_string_n(CassStatement* statement, size_t index, const char* value, size_t value_length)
   CassError cass_statement_bind_bytes(CassStatement* statement, size_t index, const cass_byte_t* value, size_t value_length)
+  CassError cass_statement_bind_bytes_by_name_n(CassStatement* statement, const char* name, size_t name_length, const cass_byte_t* value, size_t value_size)
+  CassError cass_statement_bind_string_by_name_n(CassStatement* statement, const char* name, size_t name_length, const char* value, size_t value_length)
+  CassError cass_statement_bind_bool_by_name_n(CassStatement* statement, const char* name, size_t name_length, cass_bool_t value)
+  CassError cass_statement_bind_float_by_name_n(CassStatement* statement, const char* name, size_t name_length, cass_float_t value);
+  CassError cass_statement_bind_int32_by_name_n(CassStatement* statement, const char* name, size_t name_length, cass_int32_t value);
+  CassError cass_statement_bind_null_by_name_n(CassStatement* statement, const char* name, size_t name_length);
+
+
   void cass_statement_free(CassStatement* statement)
 
   void cass_future_free(CassFuture* future)

--- a/acsylla/_cython/result/row.pyx
+++ b/acsylla/_cython/result/row.pyx
@@ -11,13 +11,14 @@ cdef class Row:
         row.cass_row = cass_row
         return row
 
-    def column_by_name(self, bytes name):
+    def column_by_name(self, str name):
         """ Returns the row column called `name`.
 
         Raises a `ColumnNotFound` exception if the column can not be found"""
         cdef const CassValue* cass_value
+        cdef bytes_name = name.encode()
 
-        cass_value = cass_row_get_column_by_name(self.cass_row, name)
+        cass_value = cass_row_get_column_by_name(self.cass_row, bytes_name)
         if (cass_value == NULL):
             raise ColumnNotFound()
 

--- a/acsylla/_cython/session/session.pyx
+++ b/acsylla/_cython/session/session.pyx
@@ -1,7 +1,7 @@
 import asyncio
 
-cdef class Session:
 
+cdef class Session:
     def __cinit__(self, Cluster cluster, object keyspace):
         self.cass_cluster = cluster.cass_cluster
         self.cass_session = cass_session_new()
@@ -16,8 +16,10 @@ cdef class Session:
         self.connected = 0
 
     async def close(self):
-        cdef CallbackWrapper cb_wrapper
         cdef CassFuture* cass_future
+        cdef CassError cass_error
+
+        cdef CallbackWrapper cb_wrapper
 
         if self.closed == 1:
             return
@@ -26,36 +28,44 @@ cdef class Session:
         # of closing it.
         self.closed = 1
 
-        cb_wrapper = CallbackWrapper.new_(
-            cass_session_close(self.cass_session),
-            self.loop
-        )
+        cass_future = cass_session_close(self.cass_session)
+        cb_wrapper = CallbackWrapper.new_(cass_future, self.loop)
 
-        await cb_wrapper.__await__()
+        try:
+            await cb_wrapper.__await__()
+            error = cass_future_error_code(cass_future)
+            if error != CASS_OK:
+                raise CassException(error)
+        finally:
+            cass_future_free(cass_future)
 
     async def _connect(self):
+        cdef CassFuture* cass_future
+        cdef CassError cass_error
+
         cdef bytes keyspace
         cdef CallbackWrapper cb_wrapper
-        cdef CassFuture* cass_future
 
         if self.keyspace is not None:
             keyspace = self.keyspace.encode()
-            cb_wrapper = CallbackWrapper.new_(
-                cass_session_connect_keyspace_n(
-                    self.cass_session,
-                    self.cass_cluster,
-                    keyspace,
-                    len(keyspace)
-                ),
-                self.loop
+            cass_future = cass_session_connect_keyspace_n(
+                self.cass_session,
+                self.cass_cluster,
+                keyspace,
+                len(keyspace)
             )
         else:
-            cb_wrapper = CallbackWrapper.new_(
-                cass_session_connect(self.cass_session, self.cass_cluster),
-                self.loop
-            )
+            cass_future = cass_session_connect(self.cass_session, self.cass_cluster)
 
-        await cb_wrapper.__await__()
+        cb_wrapper = CallbackWrapper.new_(cass_future, self.loop)
+
+        try:
+            await cb_wrapper.__await__()
+            error = cass_future_error_code(cass_future)
+            if error != CASS_OK:
+                raise CassException(error)
+        finally:
+            cass_future_free(cass_future)
 
     async def execute(self, Statement statement):
         """ Execute an statement and returns the result.
@@ -63,24 +73,64 @@ cdef class Session:
         Is responsability of the caller to know what to do with
         the results object.
         """
+        cdef CassFuture* cass_future
+        cdef CassError cass_error
+        cdef const CassResult* cass_result = NULL
+
         cdef Result result
         cdef CallbackWrapper cb_wrapper
-        cdef CassFuture* cass_future
 
         if self.closed == 1:
             raise RuntimeError("Session closed")
 
-        cb_wrapper = CallbackWrapper.new_(
-            cass_session_execute(self.cass_session, statement.cass_statement),
-            self.loop
-        )
+        cass_future = cass_session_execute(self.cass_session, statement.cass_statement)
+        cb_wrapper = CallbackWrapper.new_(cass_future, self.loop)
 
         try:
-            result = await cb_wrapper.__await__()
-        except CallbackError as callback_error:
-            if callback_error.cass_error == CASS_ERROR_SYNTAX_ERROR:
-                raise CassExceptionSyntaxError(statement)
-            else:
-                raise CassException(callback_error.cass_error)
+            await cb_wrapper.__await__()
+            cass_result = cass_future_get_result(cass_future)
+            if cass_result == NULL:
+                cass_error = cass_future_error_code(cass_future)
+                if cass_error == CASS_ERROR_SERVER_SYNTAX_ERROR:
+                    raise CassExceptionSyntaxError(statement)
+                elif cass_error == CASS_ERROR_SERVER_INVALID_QUERY:
+                    raise CassExceptionInvalidQuery(statement)
+                else:
+                    raise CassException(cass_error)
+
+            result = Result.new_(cass_result)
+        finally:
+            cass_future_free(cass_future)
 
         return result
+
+    async def create_prepared(self, str statement):
+        """ Prepares an statement."""
+        cdef CassFuture* cass_future
+        cdef CassError cass_error
+        cdef const CassPrepared* cass_prepared
+
+        cdef bytes encoded_statement
+        cdef PreparedStatement prepared
+        cdef CallbackWrapper cb_wrapper
+
+        if self.closed == 1:
+            raise RuntimeError("Session closed")
+
+        encoded_statement = statement.encode()
+
+        cass_future = cass_session_prepare_n(self.cass_session, encoded_statement, len(encoded_statement))
+        cb_wrapper = CallbackWrapper.new_(cass_future, self.loop)
+
+        try:
+            await cb_wrapper.__await__()
+            cass_prepared = cass_future_get_prepared(cass_future)
+            if cass_prepared == NULL:
+                cass_error = cass_future_error_code(cass_future)
+                raise CassException(cass_error)
+
+            prepared = PreparedStatement.new_(cass_prepared)
+        finally:
+            cass_future_free(cass_future)
+
+        return prepared

--- a/acsylla/_cython/statement/prepared.pxd
+++ b/acsylla/_cython/statement/prepared.pxd
@@ -1,3 +1,6 @@
 cdef class PreparedStatement:
     cdef:
-        CassStatement* cass_statement
+        const CassPrepared* cass_prepared
+
+    @staticmethod
+    cdef PreparedStatement new_(const CassPrepared* cass_prepared)

--- a/acsylla/_cython/statement/prepared.pyx
+++ b/acsylla/_cython/statement/prepared.pyx
@@ -1,10 +1,23 @@
 cdef class PreparedStatement:
 
     def __cinit__(self):
-        pass
+        self.cass_prepared = NULL
 
     def __dealloc__(self):
-        pass
+        cass_prepared_free(self.cass_prepared)
 
-    def __init__(self):
-        pass
+    @staticmethod
+    cdef PreparedStatement new_(const CassPrepared* cass_prepared):
+        cdef PreparedStatement prepared
+
+        prepared = PreparedStatement()
+        prepared.cass_prepared = cass_prepared
+        return prepared
+
+    def bind(self):
+        cdef CassStatement* cass_statement
+        cdef Statement statement
+
+        cass_statement = cass_prepared_bind(self.cass_prepared)
+        statement = Statement.new_from_prepared(cass_statement)
+        return statement

--- a/acsylla/_cython/statement/statement.pxd
+++ b/acsylla/_cython/statement/statement.pxd
@@ -1,7 +1,12 @@
 cdef class Statement:
     cdef:
-        int parameters
+        bint prepared
         CassStatement* cass_statement
 
-    cdef _check_index_or_raise(self, index)
+    @staticmethod
+    cdef Statement new_from_string(str statement_str, int parameters)
+
+    @staticmethod
+    cdef Statement new_from_prepared(CassStatement* cass_statement)
+
     cdef _check_bind_error_or_raise(self, CassError error)

--- a/acsylla/_cython/statement/statement.pxd
+++ b/acsylla/_cython/statement/statement.pxd
@@ -10,3 +10,4 @@ cdef class Statement:
     cdef Statement new_from_prepared(CassStatement* cass_statement)
 
     cdef _check_bind_error_or_raise(self, CassError error)
+    cdef _check_if_prepared_or_raise(self)

--- a/acsylla/_cython/statement/statement.pyx
+++ b/acsylla/_cython/statement/statement.pyx
@@ -14,6 +14,7 @@ cdef class Statement:
         encoded_statement = statement_str.encode()
 
         statement = Statement()
+        statement.prepared = 0
         statement.cass_statement = cass_statement_new_n(
             encoded_statement,
             len(encoded_statement),
@@ -35,7 +36,9 @@ cdef class Statement:
             return
  
         if error == CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS:
-            raise ValueError(f"Index out of band")
+            raise ValueError("Index out of band")
+        elif error == CASS_ERROR_LIB_NAME_DOES_NOT_EXIST:
+            raise ValueError("Name does not exist")
         else:
             raise RuntimeError("Error {} trying to bind the statement".format(error))
 
@@ -44,17 +47,17 @@ cdef class Statement:
             cass_statement_bind_null(self.cass_statement, index)
         )
 
-    def bind_int(self, int value, int index):
+    def bind_int(self, int index, int value):
         self._check_bind_error_or_raise(
             cass_statement_bind_int32(self.cass_statement, index, value)
         )
 
-    def bind_float(self, float value, int index):
+    def bind_float(self, int index, float value):
         self._check_bind_error_or_raise(
             cass_statement_bind_float(self.cass_statement, index, value)
         )
 
-    def bind_bool(self, object value, int index):
+    def bind_bool(self, int index, object value):
         if value is True:
             self._check_bind_error_or_raise(
                 cass_statement_bind_bool(self.cass_statement, index, cass_true)
@@ -67,16 +70,111 @@ cdef class Statement:
             raise ValueError("Value is not boolean")
 
 
-    def bind_string(self, str value, int index):
+    def bind_string(self, int index, str value):
         cdef bytes bytes_value = value.encode()
 
         self._check_bind_error_or_raise(
             cass_statement_bind_string_n(self.cass_statement, index, bytes_value, len(bytes_value))
         )
 
-    def bind_bytes(self, bytes value, int index):
+    def bind_bytes(self, int index, bytes value):
         self._check_bind_error_or_raise(
             cass_statement_bind_bytes(self.cass_statement, index, <const cass_byte_t*> value, len(value))
+        )
+
+    # following methods are only allowed for statements
+    # created using prepared statements
+
+    cdef _check_if_prepared_or_raise(self):
+        if self.prepared == 0:
+            raise ValueError(
+                "Method only availabe for statements created from prepared statements")
+ 
+    def bind_null_by_name(self, str name):
+        cdef bytes bytes_name
+
+        self._check_if_prepared_or_raise()
+
+        bytes_name = name.encode()
+        self._check_bind_error_or_raise(
+            cass_statement_bind_null_by_name_n(
+                self.cass_statement, bytes_name, len(bytes_name))
+        )
+
+    def bind_int_by_name(self, str name, int value):
+        cdef bytes bytes_name
+
+        self._check_if_prepared_or_raise()
+
+        bytes_name = name.encode()
+        self._check_bind_error_or_raise(
+            cass_statement_bind_int32_by_name_n(
+                self.cass_statement, bytes_name, len(bytes_name), value)
+        )
+
+
+    def bind_float_by_name(self, str name, float value):
+        cdef bytes bytes_name
+
+        self._check_if_prepared_or_raise()
+
+        bytes_name = name.encode()
+        self._check_bind_error_or_raise(
+            cass_statement_bind_float_by_name_n(
+                self.cass_statement, bytes_name, len(bytes_name), value)
+        )
+
+
+    def bind_bool_by_name(self, str name, object value):
+        cdef bytes bytes_name
+
+        self._check_if_prepared_or_raise()
+
+        bytes_name = name.encode()
+        if value is True:
+            self._check_bind_error_or_raise(
+                cass_statement_bind_bool_by_name_n(
+                    self.cass_statement, bytes_name, len(bytes_name), cass_true)
+            )
+        elif value is False:
+            self._check_bind_error_or_raise(
+                cass_statement_bind_bool_by_name_n(
+                    self.cass_statement, bytes_name, len(bytes_name), cass_false)
+            )
+        else:
+            raise ValueError("Value is not boolean")
+
+
+    def bind_string_by_name(self, str name, str value):
+        cdef bytes bytes_name
+        cdef bytes bytes_value
+
+        self._check_if_prepared_or_raise()
+
+        bytes_name = name.encode()
+        bytes_value = value.encode()
+
+        self._check_bind_error_or_raise(
+            cass_statement_bind_string_by_name_n(
+                self.cass_statement, bytes_name, len(bytes_name), bytes_value, len(bytes_value)
+            )
+        )
+
+    def bind_bytes_by_name(self, str name, bytes value):
+        cdef bytes bytes_name
+
+        self._check_if_prepared_or_raise()
+
+        bytes_name = name.encode()
+
+        self._check_bind_error_or_raise(
+            cass_statement_bind_bytes_by_name_n(
+                self.cass_statement,
+                bytes_name,
+                len(bytes_name),
+                <const cass_byte_t*> value,
+                len(value)
+            )
         )
 
 

--- a/acsylla/_cython/statement/statement.pyx
+++ b/acsylla/_cython/statement/statement.pyx
@@ -6,45 +6,55 @@ cdef class Statement:
     def __dealloc__(self):
         cass_statement_free(self.cass_statement)
 
-    def __init__(self, str statement, int parameters=0):
+    @staticmethod
+    cdef Statement new_from_string(str statement_str, int parameters):
+        cdef Statement statement
         cdef bytes encoded_statement
-        encoded_statement = statement.encode()
-        self.parameters = parameters
-        self.cass_statement = cass_statement_new_n(
+
+        encoded_statement = statement_str.encode()
+
+        statement = Statement()
+        statement.cass_statement = cass_statement_new_n(
             encoded_statement,
             len(encoded_statement),
             parameters
         )
+        return statement
 
-    cdef _check_index_or_raise(self, index):
-        if index >= self.parameters:
-            raise ValueError(f"Index {index} has to be lower than {self.parameters}")
+    @staticmethod
+    cdef Statement new_from_prepared(CassStatement* cass_statement):
+        cdef Statement statement
+
+        statement = Statement()
+        statement.cass_statement = cass_statement
+        statement.prepared = 1
+        return statement
 
     cdef _check_bind_error_or_raise(self, CassError error):
-        if error != CASS_OK:
+        if error == CASS_OK:
+            return
+ 
+        if error == CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS:
+            raise ValueError(f"Index out of band")
+        else:
             raise RuntimeError("Error {} trying to bind the statement".format(error))
 
     def bind_null(self, int index):
-        self._check_index_or_raise(index)
         self._check_bind_error_or_raise(
             cass_statement_bind_null(self.cass_statement, index)
         )
 
     def bind_int(self, int value, int index):
-        self._check_index_or_raise(index)
         self._check_bind_error_or_raise(
             cass_statement_bind_int32(self.cass_statement, index, value)
         )
 
     def bind_float(self, float value, int index):
-        self._check_index_or_raise(index)
         self._check_bind_error_or_raise(
             cass_statement_bind_float(self.cass_statement, index, value)
         )
 
     def bind_bool(self, object value, int index):
-        self._check_index_or_raise(index)
-
         if value is True:
             self._check_bind_error_or_raise(
                 cass_statement_bind_bool(self.cass_statement, index, cass_true)
@@ -60,13 +70,17 @@ cdef class Statement:
     def bind_string(self, str value, int index):
         cdef bytes bytes_value = value.encode()
 
-        self._check_index_or_raise(index)
         self._check_bind_error_or_raise(
             cass_statement_bind_string_n(self.cass_statement, index, bytes_value, len(bytes_value))
         )
 
     def bind_bytes(self, bytes value, int index):
-        self._check_index_or_raise(index)
         self._check_bind_error_or_raise(
             cass_statement_bind_bytes(self.cass_statement, index, <const cass_byte_t*> value, len(value))
         )
+
+
+def create_statement(str statement_str, int parameters=0):
+    cdef Statement statement
+    statement = Statement.new_from_string(statement_str, parameters)
+    return statement

--- a/acsylla/errors.py
+++ b/acsylla/errors.py
@@ -5,7 +5,14 @@ from acsylla._cython.cyacsylla import (
 
 from acsylla._cython.cyacsylla import (
     CassException,
-    CassExceptionSyntaxError
+    CassExceptionSyntaxError,
+    CassExceptionInvalidQuery
 )
 
-__all__ = ("ColumnNotFound", "ColumnValueError", "CassError", "CassErrorSyntaxError")
+__all__ = (
+    "ColumnNotFound",
+    "ColumnValueError",
+    "CassException",
+    "CassExceptionSyntaxError",
+    "CassExceptionInvalidQuery"
+)

--- a/benchmark/acsylla_benchmark.py
+++ b/benchmark/acsylla_benchmark.py
@@ -7,7 +7,7 @@ from typing import List
 
 import uvloop
 
-from acsylla import Cluster, Statement
+from acsylla import Cluster, create_statement
 
 uvloop.install()
 
@@ -15,20 +15,20 @@ MAX_NUMBER_OF_KEYS = 65536
 
 async def write(session, key, value):
     start = time.monotonic()
-    statement = Statement("INSERT INTO test (id, value) values(" + key + "," + value + ")")
+    statement = create_statement("INSERT INTO test (id, value) values(" + key + "," + value + ")")
     await session.execute(statement)
     return time.monotonic() - start
 
 
 async def read(session, key, value):
     start = time.monotonic()
-    statement = Statement(
+    statement = create_statement(
         "SELECT id, value FROM test WHERE id =" + key
     )
     result = await session.execute(statement)
     if result.count() > 0:
         row = result.first()
-        value = row.column_by_name(b"value").int()
+        value = row.column_by_name("value").int()
         
     return time.monotonic() - start
 

--- a/tests/test_prepared.py
+++ b/tests/test_prepared.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestPreparedStatement:
+
+    async def test_bind(self, session):
+        statement_str = "INSERT INTO test (id, value) values( ?, ?)"
+        prepared = await session.create_prepared(statement_str)
+        statement = prepared.bind()
+        assert statement is not None

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,5 +1,5 @@
 import pytest
-from acsylla import Statement
+from acsylla import create_statement
 from acsylla.errors import ColumnNotFound
 
 
@@ -11,7 +11,7 @@ class TestResult:
         id_ = next(id_generation)
 
         # try to read a none inserted value
-        statement = Statement(
+        statement = create_statement(
             "SELECT id, value FROM test WHERE id =" +
             str(id_)
         )
@@ -25,7 +25,7 @@ class TestResult:
         value = 100
 
         # insert a new value into the table
-        statement = Statement(
+        statement = create_statement(
             "INSERT INTO test (id, value) values(" +
             str(id_) +
             ', ' +
@@ -35,7 +35,7 @@ class TestResult:
         await session.execute(statement)
 
         # read the new inserted value
-        statement = Statement(
+        statement = create_statement(
             "SELECT id, value FROM test WHERE id =" +
             str(id_)
         )
@@ -55,7 +55,7 @@ class TestResult:
         value = 100
 
         # insert a new value into the table
-        statement = Statement(
+        statement = create_statement(
             "INSERT INTO test (id, value) values(" +
             str(id_) +
             ', ' +
@@ -65,7 +65,7 @@ class TestResult:
         await session.execute(statement)
 
         # read the new inserted value
-        statement = Statement(
+        statement = create_statement(
             "SELECT id, value FROM test WHERE id =" +
             str(id_)
         )
@@ -79,7 +79,7 @@ class TestResult:
         total_rows = 100
         value = 33
 
-        statement = Statement(
+        statement = create_statement(
             "INSERT INTO test (id, value) values(?, ?)",
             parameters=2
         )
@@ -94,7 +94,7 @@ class TestResult:
             await session.execute(statement)
 
         # read all results
-        statement = Statement(
+        statement = create_statement(
             "SELECT id, value FROM test WHERE id >= ? and id <= ? ALLOW FILTERING",
             parameters=2
         )
@@ -117,7 +117,7 @@ class TestResult:
         ids = [next(id_generation) for i in range(total_rows)]
 
         # try to read unavailable results
-        statement = Statement(
+        statement = create_statement(
             "SELECT id, value FROM test WHERE id >= ? and id <= ? ALLOW FILTERING",
             parameters=2
         )

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -7,39 +7,60 @@ pytestmark = pytest.mark.asyncio
 
 
 class TestResult:
-    async def test_result_no_row(self, session, id_generation):
+
+    async def _build_statement(self, session, type_, statement_str, parameters):
+        if type_ == "none_prepared":
+            statement_ = create_statement(statement_str, parameters=parameters)
+        elif type_ == "prepared":
+            prepared = await session.create_prepared(statement_str)
+            statement_ = prepared.bind()
+        else:
+            raise ValueError()
+        return statement_
+
+    @pytest.fixture(params=["none_prepared", "prepared"])
+    async def insert_statement(self, request, session):
+        statement_str = (
+            "INSERT INTO test (id, value) values(?, ?)"
+        )
+        return await self._build_statement(session, request.param, statement_str, 2)
+
+    @pytest.fixture(params=["none_prepared", "prepared"])
+    async def select_statement(self, request, session):
+        statement_str = (
+            "SELECT id, value FROM test WHERE id = ?"
+        )
+        return await self._build_statement(session, request.param, statement_str, 1)
+
+    @pytest.fixture(params=["none_prepared", "prepared"])
+    async def select_filter_statement(self, request, session):
+        statement_str = (
+            "SELECT id, value FROM test WHERE id >= :min and id <= :max ALLOW FILTERING"
+        )
+        return await self._build_statement(session, request.param, statement_str, 2)
+
+    async def test_result_no_row(self, session, select_statement, id_generation):
         id_ = next(id_generation)
 
         # try to read a none inserted value
-        statement = create_statement(
-            "SELECT id, value FROM test WHERE id =" +
-            str(id_)
-        )
-        result = await session.execute(statement)
+        select_statement.bind_int(0, id_)
+        result = await session.execute(select_statement)
 
         assert result.count() == 0
         assert result.first() is None
 
-    async def test_result_one_row(self, session, id_generation):
+    async def test_result_one_row(self, session, insert_statement, select_statement, id_generation):
         id_ = next(id_generation)
         value = 100
 
         # insert a new value into the table
-        statement = create_statement(
-            "INSERT INTO test (id, value) values(" +
-            str(id_) +
-            ', ' +
-            str(value) +
-            ')'
-        )
-        await session.execute(statement)
+        insert_statement.bind_int(0, id_)
+        insert_statement.bind_int(1, value)
+        await session.execute(insert_statement)
 
         # read the new inserted value
-        statement = create_statement(
-            "SELECT id, value FROM test WHERE id =" +
-            str(id_)
-        )
-        result = await session.execute(statement)
+        select_statement.bind_int(0, id_)
+        result = await session.execute(select_statement)
 
         assert result.count() == 1
         assert result.column_count() == 2
@@ -47,8 +68,8 @@ class TestResult:
         row = result.first()
 
         # check that the columns have the expected values
-        assert row.column_by_name(b"id").int() == id_
-        assert row.column_by_name(b"value").int() == value
+        assert row.column_by_name("id").int() == id_
+        assert row.column_by_name("value").int() == value
 
     async def test_result_invalid_column_name(self, session, id_generation):
         id_ = next(id_generation)
@@ -73,62 +94,50 @@ class TestResult:
 
         row = result.first()
         with pytest.raises(ColumnNotFound):
-            row.column_by_name(b"invalid_column_name")
+            row.column_by_name("invalid_column_name")
 
-    async def test_result_multiple_rows(self, session, id_generation):
+
+    async def test_result_multiple_rows(self, session, insert_statement, select_filter_statement, id_generation):
         total_rows = 100
         value = 33
 
-        statement = create_statement(
-            "INSERT INTO test (id, value) values(?, ?)",
-            parameters=2
-        )
-
-        statement.bind_int(value, 1)
+        insert_statement.bind_int(1, value)
 
         ids = [next(id_generation) for i in range(total_rows)]
 
         # write results 
         for id_ in ids:
-            statement.bind_int(id_, 0)
-            await session.execute(statement)
+            insert_statement.bind_int(0, id_)
+            await session.execute(insert_statement)
 
         # read all results
-        statement = create_statement(
-            "SELECT id, value FROM test WHERE id >= ? and id <= ? ALLOW FILTERING",
-            parameters=2
-        )
-        statement.bind_int(ids[0], 0)
-        statement.bind_int(ids[-1], 1)
-        result = await session.execute(statement)
+        select_filter_statement.bind_int(0, ids[0])
+        select_filter_statement.bind_int(1, ids[-1])
+        result = await session.execute(select_filter_statement)
 
         assert result.count() == total_rows
         assert result.column_count() == 2
 
-        ids_returned = [row.column_by_name(b"id").int() for row in result.all()]
-        values_returned = [row.column_by_name(b"value").int() for row in result.all()]
+        ids_returned = [row.column_by_name("id").int() for row in result.all()]
+        values_returned = [row.column_by_name("value").int() for row in result.all()]
 
         # values returned are unsorted
         assert sorted(ids_returned) == sorted(ids)
         assert values_returned == [value] * total_rows
 
-    async def test_result_multiple_no_rows(self, session, id_generation):
+    async def test_result_multiple_no_rows(self, session, id_generation, select_filter_statement):
         total_rows = 100
         ids = [next(id_generation) for i in range(total_rows)]
 
         # try to read unavailable results
-        statement = create_statement(
-            "SELECT id, value FROM test WHERE id >= ? and id <= ? ALLOW FILTERING",
-            parameters=2
-        )
-        statement.bind_int(ids[0], 0)
-        statement.bind_int(ids[-1], 1)
-        result = await session.execute(statement)
+        select_filter_statement.bind_int(0, ids[0])
+        select_filter_statement.bind_int(1, ids[-1])
+        result = await session.execute(select_filter_statement)
 
         assert result.count() == 0
 
-        ids_returned = [row.column_by_name(b"id").int() for row in result.all()]
-        values_returned = [row.column_by_name(b"value").int() for row in result.all()]
+        ids_returned = [row.column_by_name("id").int() for row in result.all()]
+        values_returned = [row.column_by_name("value").int() for row in result.all()]
 
         assert ids_returned == []
         assert values_returned == []

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -34,40 +34,101 @@ class TestStatement:
             statement.bind_null(TestStatement.OUT_OF_BAND_PARAMETER)
 
     def test_bind_int(self, statement):
-        statement.bind_int(10, 2)
+        statement.bind_int(2, 10)
 
     def test_bind_int_invalid_index(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_int(10, TestStatement.OUT_OF_BAND_PARAMETER)
+            statement.bind_int(TestStatement.OUT_OF_BAND_PARAMETER, 10)
 
     def test_bind_float(self, statement):
-        statement.bind_float(10.0, 3)
+        statement.bind_float(3, 10.0)
 
     def test_bind_float_invalid_index(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_float(10.0, TestStatement.OUT_OF_BAND_PARAMETER)
+            statement.bind_float(TestStatement.OUT_OF_BAND_PARAMETER, 10.0)
 
     def test_bind_bool(self, statement):
-        statement.bind_bool(True, 4)
+        statement.bind_bool(4, True)
 
     def test_bind_bool_invalid_object(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_bool("", 4)
+            statement.bind_bool(4, "")
 
     def test_bind_bool_invalid_index(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_bool(True, TestStatement.OUT_OF_BAND_PARAMETER)
+            statement.bind_bool(TestStatement.OUT_OF_BAND_PARAMETER, True)
 
     def test_bind_string(self, statement):
-        statement.bind_string("acsylla", 5)
+        statement.bind_string(5, "acsylla")
 
     def test_bind_string_invalid_index(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_string("acsylla", TestStatement.OUT_OF_BAND_PARAMETER)
+            statement.bind_string(TestStatement.OUT_OF_BAND_PARAMETER, "acsylla")
 
     def test_bind_bytes(self, statement):
-        statement.bind_bytes(b"acsylla", 6)
+        statement.bind_bytes(6, b"acsylla")
 
     def test_bind_bytes_invalid_index(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_bytes(b"acsylla", TestStatement.OUT_OF_BAND_PARAMETER)
+            statement.bind_bytes(TestStatement.OUT_OF_BAND_PARAMETER, b"acsylla")
+
+
+class TestStatementOnlyPrepared:
+    """Special tests for testing some methods that are only allowed for statements
+    that were created by using prepared statements."""
+
+    @pytest.fixture
+    async def statement(self, session):
+        statement_str = (
+            "INSERT INTO test (id, value, value_int, value_float, value_bool, value_text, value_blob) values " +
+            "(?, ?, ?, ?, ?, ?, ?)"
+        )
+        prepared = await session.create_prepared(statement_str)
+        statement_ = prepared.bind()
+        return statement_
+
+    def test_bind_null_by_name(self, statement):
+        statement.bind_null_by_name("value")
+
+    def test_bind_null_by_name_invalid_name(self, statement):
+        with pytest.raises(ValueError):
+            statement.bind_null_by_name("invalid_field")
+
+    def test_bind_int_by_name(self, statement):
+        statement.bind_int_by_name("value_int", 10)
+
+    def test_bind_int_by_name_invalid_name(self, statement):
+        with pytest.raises(ValueError):
+            statement.bind_int_by_name("invalid_field", 10)
+
+    def test_bind_float_by_name(self, statement):
+        statement.bind_float_by_name("value_float", 10.0)
+
+    def test_bind_float_by_name_invalid_name(self, statement):
+        with pytest.raises(ValueError):
+            statement.bind_float_by_name("invalid_field", 10.0)
+
+    def test_bind_bool_by_name(self, statement):
+        statement.bind_bool_by_name("value_bool", True)
+
+    def test_bind_bool_by_name_invalid_object(self, statement):
+        with pytest.raises(ValueError):
+            statement.bind_bool_by_name("value_bool", "")
+
+    def test_bind_bool_by_name_invalid_name(self, statement):
+        with pytest.raises(ValueError):
+            statement.bind_bool_by_name("invalid_field", True)
+
+    def test_bind_string_by_name(self, statement):
+        statement.bind_string_by_name("value_text", "acsylla")
+
+    def test_bind_string_by_name_invalid_name(self, statement):
+        with pytest.raises(ValueError):
+            statement.bind_string_by_name("invalid_field", "acsylla")
+
+    def test_bind_bytes_by_name(self, statement):
+        statement.bind_bytes_by_name("value_blob", b"acsylla")
+
+    def test_bind_bytes_by_name_invalid_name(self, statement):
+        with pytest.raises(ValueError):
+            statement.bind_bytes_by_name("invalid_field", b"acsylla")

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -1,6 +1,6 @@
 import pytest
 
-from acsylla import Statement
+from acsylla import create_statement
 
 
 pytestmark = pytest.mark.asyncio
@@ -8,61 +8,66 @@ pytestmark = pytest.mark.asyncio
 
 class TestStatement:
 
-    def test_bind_null(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
-        statement.bind_null(0)
+    OUT_OF_BAND_PARAMETER = 10
 
-    def test_bind_null_invalid_index(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
+    @pytest.fixture(params=["none_prepared", "prepared"])
+    async def statement(self, request, session):
+        statement_str = (
+            "INSERT INTO test (id, value, value_int, value_float, value_bool, value_text, value_blob) values " +
+            "(?, ?, ?, ?, ?, ?, ?)"
+        )
+        if request.param == "none_prepared":
+            statement_ = create_statement(statement_str, parameters=7)
+        elif request.param == "prepared":
+            prepared = await session.create_prepared(statement_str)
+            statement_ = prepared.bind()
+        else:
+            raise ValueError()
+
+        return statement_
+
+    def test_bind_null(self, statement):
+        statement.bind_null(1)
+
+    def test_bind_null_invalid_index(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_null(1)
+            statement.bind_null(TestStatement.OUT_OF_BAND_PARAMETER)
 
-    def test_bind_int(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
-        statement.bind_int(10, 0)
+    def test_bind_int(self, statement):
+        statement.bind_int(10, 2)
 
-    def test_bind_int_invalid_index(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
+    def test_bind_int_invalid_index(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_int(10, 1)
+            statement.bind_int(10, TestStatement.OUT_OF_BAND_PARAMETER)
 
-    def test_bind_float(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
-        statement.bind_int(10.0, 0)
+    def test_bind_float(self, statement):
+        statement.bind_float(10.0, 3)
 
-    def test_bind_float_invalid_index(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
+    def test_bind_float_invalid_index(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_float(10.0, 1)
+            statement.bind_float(10.0, TestStatement.OUT_OF_BAND_PARAMETER)
 
-    def test_bind_bool(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
-        statement.bind_bool(True, 0)
+    def test_bind_bool(self, statement):
+        statement.bind_bool(True, 4)
 
-    def test_bind_bool_invalid_object(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
+    def test_bind_bool_invalid_object(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_bool("", 0)
+            statement.bind_bool("", 4)
 
-    def test_bind_bool_invalid_index(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
+    def test_bind_bool_invalid_index(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_bool(True, 1)
+            statement.bind_bool(True, TestStatement.OUT_OF_BAND_PARAMETER)
 
-    def test_bind_string(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
-        statement.bind_string("acsylla", 0)
+    def test_bind_string(self, statement):
+        statement.bind_string("acsylla", 5)
 
-    def test_bind_string_invalid_index(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
+    def test_bind_string_invalid_index(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_string("acsylla", 1)
+            statement.bind_string("acsylla", TestStatement.OUT_OF_BAND_PARAMETER)
 
-    def test_bind_bytes(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
-        statement.bind_bytes(b"acsylla", 0)
+    def test_bind_bytes(self, statement):
+        statement.bind_bytes(b"acsylla", 6)
 
-    def test_bind_bytes_invalid_index(self):
-        statement = Statement("SELECT id FROM test WHERE id = ?", parameters=1)
+    def test_bind_bytes_invalid_index(self, statement):
         with pytest.raises(ValueError):
-            statement.bind_bytes(b"acsylla", 1)
+            statement.bind_bytes(b"acsylla", TestStatement.OUT_OF_BAND_PARAMETER)


### PR DESCRIPTION
Prepared statments are created by using the `session.create_prepared()` coroutine.
Once you have a prepared statment, servers will have them cached, a simple `statement`
can be build by just using the `prepared.bind()` function.

Other changes incorporated in this PR:

- We had to modify CallbackWrapper due to the duality of the cass_future, since
this PR the CallbackWrapper only takes the responsability of wake up the future
and schedule the cassandra callback. Parsing the results from the cassandra future
becomes responsability of the caller.
- Added a couple of more errors. There is a lot of work to do here.
- For creating statements the `create_statement` will be the public interface, since
behind the scenes the object is used either by raw statements and prepared statments and
the constructor can not be public.