### PR TITLE
Row gets a reference of the result

### DIFF
--- a/acsylla/_cython/cass_errors.pyx
+++ b/acsylla/_cython/cass_errors.pyx
@@ -3,6 +3,10 @@ class CassException(Exception):
     pass
 
 
+class CassExceptionConnectionError(CassException):
+    """ Raised when server can't be reached. """
+
+
 class CassExceptionSyntaxError(CassException):
     """ Raised when a statment presented a syntax error. """
 

--- a/acsylla/_cython/cpp_cassandra.pxi
+++ b/acsylla/_cython/cpp_cassandra.pxi
@@ -9,6 +9,7 @@ cdef extern from "cassandra.h":
 
   ctypedef enum CassError:
     CASS_OK
+    CASS_ERROR_LIB_NO_HOSTS_AVAILABLE
     CASS_ERROR_LIB_NAME_DOES_NOT_EXIST
     CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS
     CASS_ERROR_SERVER_SYNTAX_ERROR

--- a/acsylla/_cython/result/result.pyx
+++ b/acsylla/_cython/result/result.pyx
@@ -38,7 +38,7 @@ cdef class Result:
         if (cass_row == NULL):
             return None
 
-        return Row.new_(cass_row)
+        return Row.new_(cass_row, self)
 
     def all(self):
         """ Return the all rows using of a result, using an 
@@ -53,6 +53,6 @@ cdef class Result:
             cass_iterator = cass_iterator_from_result(self.cass_result)
             while (cass_iterator_next(cass_iterator) == cass_true):
                 cass_row = cass_iterator_get_row(cass_iterator)
-                yield Row.new_(cass_row)
+                yield Row.new_(cass_row, self)
         finally:
             cass_iterator_free(cass_iterator)

--- a/acsylla/_cython/result/row.pxd
+++ b/acsylla/_cython/result/row.pxd
@@ -1,6 +1,7 @@
 cdef class Row:
     cdef:
         const CassRow* cass_row
+        Result result
 
     @staticmethod
-    cdef Row new_(const CassRow* cass_row)
+    cdef Row new_(const CassRow* cass_row, Result result)

--- a/acsylla/_cython/result/row.pyx
+++ b/acsylla/_cython/result/row.pyx
@@ -4,11 +4,17 @@ cdef class Row:
         self.cass_row = NULL
 
     @staticmethod
-    cdef Row new_(const CassRow* cass_row):
+    cdef Row new_(const CassRow* cass_row, Result result):
         cdef Row row
 
         row = Row()
         row.cass_row = cass_row
+
+        # Increase the references to the result object, behind the scenes
+        # Cassandra uses the data owned by the result object, so we need to
+        # keep the object alive while the row is still in use.
+        row.result = result 
+
         return row
 
     def column_by_name(self, str name):

--- a/acsylla/_cython/session/session.pyx
+++ b/acsylla/_cython/session/session.pyx
@@ -63,7 +63,10 @@ cdef class Session:
             await cb_wrapper.__await__()
             error = cass_future_error_code(cass_future)
             if error != CASS_OK:
-                raise CassException(error)
+                if error == CASS_ERROR_LIB_NO_HOSTS_AVAILABLE:
+                    raise CassExceptionConnectionError()
+                else:
+                    raise CassException(error)
         finally:
             cass_future_free(cass_future)
 

--- a/acsylla/errors.py
+++ b/acsylla/errors.py
@@ -6,7 +6,8 @@ from acsylla._cython.cyacsylla import (
 from acsylla._cython.cyacsylla import (
     CassException,
     CassExceptionSyntaxError,
-    CassExceptionInvalidQuery
+    CassExceptionInvalidQuery,
+    CassExceptionConnectionError
 )
 
 __all__ = (
@@ -14,5 +15,6 @@ __all__ = (
     "ColumnValueError",
     "CassException",
     "CassExceptionSyntaxError",
-    "CassExceptionInvalidQuery"
+    "CassExceptionInvalidQuery",
+    "CassExceptionConnectionError"
 )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,7 +4,8 @@ import pytest
 from acsylla import Cluster, create_statement
 from acsylla.errors import (
     CassExceptionSyntaxError,
-    CassExceptionInvalidQuery
+    CassExceptionInvalidQuery,
+    CassExceptionConnectionError
 )
 
 pytestmark = pytest.mark.asyncio
@@ -24,10 +25,9 @@ class TestSession:
 
         await session.close()
 
-    @pytest.mark.xfail(reason="Needs investigation")
     async def test_create_session_invalid_host(self, keyspace):
-        cluster = Cluster(["127.0.0.2"])
-        with pytest.raises(Exception):
+        cluster = Cluster(["1.0.0.0"])
+        with pytest.raises(CassExceptionConnectionError):
             session = await cluster.create_session(keyspace=keyspace)
 
     async def test_execute(self, session):


### PR DESCRIPTION
Cassandra behind the scenes fetches rows and results from the cass
results object, we need to keep the Results object alive while there
is at leas one row object still alive.

Addressed the test that was xfailing when no exception was raised in
case on having a none reachable host configured.

FIxes https://github.com/pfreixes/acsylla/issues/5