### PR TITLE
Add Python interfaces

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,7 @@
+[settings]
+force_alphabetical_sort = True
+force_single_line = True
+not_skip = __init__.py
+line_length = 120
+wrap_length = 120
+skip_glob = _cython,venv,benchmark

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,18 @@ install-dev: compile
 install: compile
 	$(PIP) install -e .
 
+format:
+	isort --recursive .
+	black .
+
+lint:
+	isort --check-only --recursive .
+	black --check .
+	flake8 --config setup.cfg
+
+mypy:
+	mypy -p acsylla -p tests.test_types
+
 test: 
 	pytest -sv tests
 
@@ -36,4 +48,4 @@ stress:
 	python benchmark/acsylla_benchmark.py --duration 10 --concurrency 32
 
 
-.PHONY: clean setup-build install install-dev compile test stress
+.PHONY: clean setup-build install install-dev compile test stress mypy lint format

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,27 @@ acsylla
 
 WORK IN PROGRESS, use only for developing
 
+The following snippet shows the minimal stuff that would be needed for creating a new ``Session``
+object for the keyspace ``acsylla`` and then peform a query for reading a set of rows.
+
+.. code-block:: python
+
+    import asyncio
+    import acsylla
+    async def main():
+        cluster = acsylla.create_cluster([host])
+        session = await cluster.create_session(keyspace="acsylla")
+        statement = ascylla.create_statement("SELECT id, value FROM test WHERE id = 100")
+        result = await session.execute(statement)
+        row = result.first()
+        value = row.column_by_name("value")
+        await session.close()
+    asyncio.run(main())
+
+
+Acsylla comes with a minimal support for the following objects: ``Cluster``, ``Session``,
+``Statement``, ``PreparedStatement``, ``Batch``, ``Result``, ``Row`` and ``Value``.
+
 
 Developing
 ============

--- a/acsylla/__init__.py
+++ b/acsylla/__init__.py
@@ -1,15 +1,33 @@
-from acsylla._cython.cyacsylla import (
+from . import errors
+from .base import (
+    Batch,
     Cluster,
+    PreparedStatement,
+    Result,
+    Row,
+    Session,
+    Statement,
+    Value,
+)
+from .factories import (
     create_batch_logged,
     create_batch_unlogged,
-    create_statement
+    create_cluster,
+    create_statement,
 )
-from . import errors
 
 __all__ = (
     "Cluster",
+    "Session",
+    "Statement",
+    "PreparedStatement",
+    "Batch",
+    "Result",
+    "Row",
+    "Value",
+    "create_cluster",
+    "create_statement",
     "create_batch_logged",
     "create_batch_unlogged",
-    "create_statement",
-    "errors"
+    "errors",
 )

--- a/acsylla/base.py
+++ b/acsylla/base.py
@@ -1,0 +1,165 @@
+"""Abstract base classes, use them for documentation or for adding
+types in your functions."""
+from abc import ABCMeta, abstractmethod
+from typing import Iterable, Optional
+
+
+class Cluster(metaclass=ABCMeta):
+    """Provides a Cluster instance class. Use the factory `create_cluster`
+    for creating a new instance"""
+
+    @abstractmethod
+    async def create_session(self, keyspace: Optional[str] = None) -> "Session":
+        """Returns a new session by using the Cluster configuration.
+
+        If Keyspace is provided, the session will be bound to the keyspace and
+        any statment, unlesss says the opposite, will be using that keyspace.
+
+        The coroutine will try to make a connection to the cluster hosts.
+        """
+
+
+class Session(metaclass=ABCMeta):
+    """Provides a Session instance class. Use the the
+    `Cluster.create_session` coroutine for creating a new instance"""
+
+    @abstractmethod
+    async def close(self):
+        """ Closes a session.
+
+        After calling this method no more executions will be allowed
+        raising the proper excetion if this is the case.
+        """
+
+    @abstractmethod
+    async def execute(self, statement: "Statement") -> "Result":
+        """ Executes an statement and returns the result."""
+
+    @abstractmethod
+    async def create_prepared(self, statement: str) -> "PreparedStatement":
+        """ Prepares an statement."""
+
+    @abstractmethod
+    async def execute_batch(self, batch: "Batch") -> None:
+        """ Executes a batch of statements."""
+
+
+class Statement(metaclass=ABCMeta):
+    """Provides a Statement instance class. Use the the
+    `create_statement` factory for creating a new instance"""
+
+    @abstractmethod
+    def bind_null(self, index: int) -> None:
+        """ Binds the `null` value to a specific index parameter."""
+
+    @abstractmethod
+    def bind_int(self, index: int, value: int) -> None:
+        """ Binds the int value to a specific index parameter."""
+
+    @abstractmethod
+    def bind_float(self, index: int, value: float) -> None:
+        """ Binds the float value to a specific index parameter."""
+
+    @abstractmethod
+    def bind_bool(self, index: int, value: bool) -> None:
+        """ Binds the bool value to a specific index parameter."""
+
+    @abstractmethod
+    def bind_string(self, index: int, value: str) -> None:
+        """ Binds the str value to a specific index parameter."""
+
+    @abstractmethod
+    def bind_bytes(self, index: int, value: bytes) -> None:
+        """ Binds the bytes value to a specific index parameter."""
+
+    # following methods are only allowed for statements
+    # created using prepared statements
+
+    @abstractmethod
+    def bind_null_by_name(self, name: str) -> None:
+        """ Binds the `null` value to a specific parameter."""
+
+    @abstractmethod
+    def bind_int_by_name(self, name: str, value: int) -> None:
+        """ Binds the int value to a specific parameter."""
+
+    @abstractmethod
+    def bind_float_by_name(self, name: str, value: float) -> None:
+        """ Binds the float value to a specific parameter."""
+
+    @abstractmethod
+    def bind_bool_by_name(self, name: str, value: bool) -> None:
+        """ Binds the bool value to a specific parameter."""
+
+    @abstractmethod
+    def bind_string_by_name(self, name: str, value: str) -> None:
+        """ Binds the str value to a specific parameter."""
+
+    @abstractmethod
+    def bind_bytes_by_name(self, name: str, value: bytes) -> None:
+        """ Binds the bytes value to a specific parameter."""
+
+
+class PreparedStatement(metaclass=ABCMeta):
+    """Provides a PreparedStatement instance class. Use the
+    `session.create_prepared()` coroutine for creating a new instance"""
+
+    @abstractmethod
+    def bind(self) -> Statement:
+        """ Returns a new statment using the prepared."""
+
+
+class Batch(metaclass=ABCMeta):
+    """Provides a Batch instance class. Use the
+    `create_batch_logged()` and `create_batch_unlogged` factories
+    for creating a new instance."""
+
+    @abstractmethod
+    def add_statement(self, statement: Statement) -> None:
+        """ Adds a new statement to the batch."""
+
+
+class Result(metaclass=ABCMeta):
+    """Provides a result instance class. Use the
+    `session.execute()` coroutine for getting the result
+    from a query"""
+
+    @abstractmethod
+    def count(self) -> int:
+        """ Returns the total rows of the result"""
+
+    @abstractmethod
+    def column_count(self) -> int:
+        """ Returns the total columns returned"""
+
+    @abstractmethod
+    def first(self) -> Optional["Row"]:
+        """ Return the first result, if there is no row
+        returns None.
+        """
+
+    @abstractmethod
+    def all(self) -> Iterable["Row"]:
+        """ Return the all rows using of a result, using an
+        iterator.
+
+        If there is no rows iterator returns no rows.
+        """
+
+
+class Row(metaclass=ABCMeta):
+    """Provides access to a row of a `Result`"""
+
+    @abstractmethod
+    def column_by_name(self, name: str) -> "Value":
+        """ Returns the row column value called by `name`.
+
+        Raises a `ColumnNotFound` exception if the column can not be found"""
+
+
+class Value(metaclass=ABCMeta):
+    """Provides access to a column value of a `Row`"""
+
+    @abstractmethod
+    def int(self) -> int:
+        """ Returns the int value associated to a column."""

--- a/acsylla/errors.py
+++ b/acsylla/errors.py
@@ -1,13 +1,10 @@
 from acsylla._cython.cyacsylla import (
-    ColumnNotFound,
-    ColumnValueError
-)
-
-from acsylla._cython.cyacsylla import (
     CassException,
-    CassExceptionSyntaxError,
+    CassExceptionConnectionError,
     CassExceptionInvalidQuery,
-    CassExceptionConnectionError
+    CassExceptionSyntaxError,
+    ColumnNotFound,
+    ColumnValueError,
 )
 
 __all__ = (
@@ -16,5 +13,5 @@ __all__ = (
     "CassException",
     "CassExceptionSyntaxError",
     "CassExceptionInvalidQuery",
-    "CassExceptionConnectionError"
+    "CassExceptionConnectionError",
 )

--- a/acsylla/factories.py
+++ b/acsylla/factories.py
@@ -1,0 +1,19 @@
+from . import _cython
+from .base import Batch, Cluster, Statement
+from typing import List
+
+
+def create_cluster(contact_points: List[str], protocol_version: int = 3) -> Cluster:
+    return _cython.cyacsylla.Cluster(contact_points, protocol_version=protocol_version)
+
+
+def create_statement(statement: str, parameters: int = 0) -> Statement:
+    return _cython.cyacsylla.create_statement(statement, parameters=parameters)
+
+
+def create_batch_logged() -> Batch:
+    return _cython.cyacsylla.create_batch_logged()
+
+
+def create_batch_unlogged() -> Batch:
+    return _cython.cyacsylla.create_batch_logged()

--- a/benchmark/acsylla_benchmark.py
+++ b/benchmark/acsylla_benchmark.py
@@ -1,17 +1,16 @@
+from acsylla import Cluster, create_statement
+
 import argparse
 import asyncio
 import logging
 import random
 import time
-from typing import List
-
 import uvloop
-
-from acsylla import Cluster, create_statement
 
 uvloop.install()
 
 MAX_NUMBER_OF_KEYS = 65536
+
 
 async def write(session, key, value):
     start = time.monotonic()
@@ -22,14 +21,12 @@ async def write(session, key, value):
 
 async def read(session, key, value):
     start = time.monotonic()
-    statement = create_statement(
-        "SELECT id, value FROM test WHERE id =" + key
-    )
+    statement = create_statement("SELECT id, value FROM test WHERE id =" + key)
     result = await session.execute(statement)
     if result.count() > 0:
         row = result.first()
-        value = row.column_by_name("value").int()
-        
+        _ = row.column_by_name("value").int()
+
     return time.monotonic() - start
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,3 @@ skip_covered = true
 [tool.coverage.run]
 branch = true
 source = ["acsylla"]
-
-[build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[tool.black]
+line-length = 120
+target-version = ['py38']
+include = '\.pyi?$'
+exclude = '''
+
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \venv
+    | _build
+    | buck-out
+    | build
+    | dist
+    | acsylla/_cython
+  )/
+  | foo.py           # also separately exclude a file named foo.py in
+                     # the root of the project
+)
+'''
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+
+[tool.coverage.run]
+branch = true
+source = ["acsylla"]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[flake8]
+max-line-length = 120
+exclude = .eggs,_cython,venv
+
+[mypy-acsylla._cython.cyacsylla]
+ignore_missing_imports = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True
+
+[isort]
+line_length = 120
+include_trailing_comma=True
+force_grid_wrap=4
+use_parentheses=True
+force_single_line=False
+multi_line_output=3
+skip_glob = _cython,venv,benchmark

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
+from setuptools import Extension, setup
+
 import os
 import re
 import sys
-
-from setuptools import Extension, setup
 
 if sys.platform in ("win32", "cygwin", "cli"):
     raise RuntimeError("acsylla does not support Windows at the moment")
@@ -22,7 +22,7 @@ extensions = [
         include_dirs=[CPP_CASSANDRA_INCLUDE_DIR],
         extra_objects=[CPP_CASSANDRA_STATIC_LIB_DIR],
         extra_compile_args=["-std=c++11"],
-        libraries=["crypto", "ssl", "uv", "z"]
+        libraries=["crypto", "ssl", "uv", "z"],
     )
 ]
 
@@ -36,6 +36,7 @@ dev_requires = [
     "black==19.10b0",
     "isort==4.3.21",
     "flake8==3.7.9",
+    "mypy==0.782",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,28 +1,30 @@
-import asyncio
-import pytest
-import time
+from acsylla import create_cluster, create_statement
 
-from acsylla import Cluster, create_statement
+import pytest
+
 
 @pytest.fixture
 def keyspace():
     return "acsylla"
 
+
 @pytest.fixture
 def host():
     return "127.0.0.1"
 
+
 @pytest.fixture
 async def cluster(event_loop, host):
-    return Cluster([host])
+    return create_cluster([host])
+
 
 @pytest.fixture
 async def session(event_loop, cluster, keyspace):
     # Create the acsylla keyspace if it does not exist yet
     session_without_keyspace = await cluster.create_session()
     create_keyspace_statement = create_statement(
-        "CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = ".format(keyspace) +
-        "{ 'class': 'SimpleStrategy', 'replication_factor': 1}"
+        "CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = ".format(keyspace)
+        + "{ 'class': 'SimpleStrategy', 'replication_factor': 1}"
     )
     await session_without_keyspace.execute(create_keyspace_statement)
     await session_without_keyspace.close()
@@ -32,27 +34,26 @@ async def session(event_loop, cluster, keyspace):
     # Drop table if exits, will truncate any data used before
     # and will enforce in the next step that if the schema of
     # table changed is used during the tests.
-    create_table_statement = create_statement(
-        "DROP TABLE IF EXISTS test")
+    create_table_statement = create_statement("DROP TABLE IF EXISTS test")
     await session.execute(create_table_statement)
 
     # Create the table test in the acsylla keyspace
     create_table_statement = create_statement(
-        "CREATE TABLE test(id int PRIMARY KEY," +
-        "value int," +
-        "value_int int," +
-        "value_float float," +
-        "value_bool boolean," +
-        "value_text text," +
-        "value_blob blob)"
+        "CREATE TABLE test(id int PRIMARY KEY,"
+        + "value int,"
+        + "value_int int,"
+        + "value_float float,"
+        + "value_bool boolean,"
+        + "value_text text,"
+        + "value_blob blob)"
     )
     await session.execute(create_table_statement)
-
 
     try:
         yield session
     finally:
         await session.close()
+
 
 @pytest.fixture(scope="session")
 def id_generation():

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,23 +1,14 @@
+from acsylla import create_batch_logged, create_batch_unlogged, create_statement
+
 import pytest
-
-from acsylla import (
-    create_batch_logged,
-    create_batch_unlogged,
-    create_statement
-)
-
 
 pytestmark = pytest.mark.asyncio
 
 
 class TestBatch:
-
     @pytest.fixture(params=["none_prepared", "prepared"])
     async def statement(self, request, session):
-        statement_str = (
-            "INSERT INTO test (id, value) values " +
-            "(?, ?)"
-        )
+        statement_str = "INSERT INTO test (id, value) values " + "(?, ?)"
         if request.param == "none_prepared":
             statement_ = create_statement(statement_str, parameters=2)
         elif request.param == "prepared":

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,16 +1,15 @@
+from acsylla import create_cluster
+
 import pytest
-
-from acsylla import Cluster
-
 
 pytestmark = pytest.mark.asyncio
 
 
-class TestCluster:
+class Testcreate_cluster:
     async def test_cluster_empty_host(self):
         with pytest.raises(ValueError):
-            Cluster([])
+            create_cluster([])
 
     async def test_cluster_invalid_protocol_version(self, host):
         with pytest.raises(ValueError):
-            Cluster([host], protocol_version=-1)
+            create_cluster([host], protocol_version=-1)

--- a/tests/test_prepared.py
+++ b/tests/test_prepared.py
@@ -1,11 +1,9 @@
 import pytest
 
-
 pytestmark = pytest.mark.asyncio
 
 
 class TestPreparedStatement:
-
     async def test_bind(self, session):
         statement_str = "INSERT INTO test (id, value) values( ?, ?)"
         prepared = await session.create_prepared(statement_str)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,13 +1,12 @@
-import pytest
 from acsylla import create_statement
 from acsylla.errors import ColumnNotFound
 
+import pytest
 
 pytestmark = pytest.mark.asyncio
 
 
 class TestResult:
-
     async def _build_statement(self, session, type_, statement_str, parameters):
         if type_ == "none_prepared":
             statement_ = create_statement(statement_str, parameters=parameters)
@@ -20,23 +19,17 @@ class TestResult:
 
     @pytest.fixture(params=["none_prepared", "prepared"])
     async def insert_statement(self, request, session):
-        statement_str = (
-            "INSERT INTO test (id, value) values(?, ?)"
-        )
+        statement_str = "INSERT INTO test (id, value) values(?, ?)"
         return await self._build_statement(session, request.param, statement_str, 2)
 
     @pytest.fixture(params=["none_prepared", "prepared"])
     async def select_statement(self, request, session):
-        statement_str = (
-            "SELECT id, value FROM test WHERE id = ?"
-        )
+        statement_str = "SELECT id, value FROM test WHERE id = ?"
         return await self._build_statement(session, request.param, statement_str, 1)
 
     @pytest.fixture(params=["none_prepared", "prepared"])
     async def select_filter_statement(self, request, session):
-        statement_str = (
-            "SELECT id, value FROM test WHERE id >= :min and id <= :max ALLOW FILTERING"
-        )
+        statement_str = "SELECT id, value FROM test WHERE id >= :min and id <= :max ALLOW FILTERING"
         return await self._build_statement(session, request.param, statement_str, 2)
 
     async def test_result_no_row(self, session, select_statement, id_generation):
@@ -76,26 +69,16 @@ class TestResult:
         value = 100
 
         # insert a new value into the table
-        statement = create_statement(
-            "INSERT INTO test (id, value) values(" +
-            str(id_) +
-            ', ' +
-            str(value) +
-            ')'
-        )
+        statement = create_statement("INSERT INTO test (id, value) values(" + str(id_) + ", " + str(value) + ")")
         await session.execute(statement)
 
         # read the new inserted value
-        statement = create_statement(
-            "SELECT id, value FROM test WHERE id =" +
-            str(id_)
-        )
+        statement = create_statement("SELECT id, value FROM test WHERE id =" + str(id_))
         result = await session.execute(statement)
 
         row = result.first()
         with pytest.raises(ColumnNotFound):
             row.column_by_name("invalid_column_name")
-
 
     async def test_result_multiple_rows(self, session, insert_statement, select_filter_statement, id_generation):
         total_rows = 100
@@ -105,7 +88,7 @@ class TestResult:
 
         ids = [next(id_generation) for i in range(total_rows)]
 
-        # write results 
+        # write results
         for id_ in ids:
             insert_statement.bind_int(0, id_)
             await session.execute(insert_statement)

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -1,7 +1,6 @@
-import pytest
-
 from acsylla import create_statement
 
+import pytest
 
 pytestmark = pytest.mark.asyncio
 
@@ -13,8 +12,8 @@ class TestStatement:
     @pytest.fixture(params=["none_prepared", "prepared"])
     async def statement(self, request, session):
         statement_str = (
-            "INSERT INTO test (id, value, value_int, value_float, value_bool, value_text, value_blob) values " +
-            "(?, ?, ?, ?, ?, ?, ?)"
+            "INSERT INTO test (id, value, value_int, value_float, value_bool, value_text, value_blob) values "
+            + "(?, ?, ?, ?, ?, ?, ?)"
         )
         if request.param == "none_prepared":
             statement_ = create_statement(statement_str, parameters=7)
@@ -80,8 +79,8 @@ class TestStatementOnlyPrepared:
     @pytest.fixture
     async def statement(self, session):
         statement_str = (
-            "INSERT INTO test (id, value, value_int, value_float, value_bool, value_text, value_blob) values " +
-            "(?, ?, ?, ?, ?, ?, ?)"
+            "INSERT INTO test (id, value, value_int, value_float, value_bool, value_text, value_blob) values "
+            + "(?, ?, ?, ?, ?, ?, ?)"
         )
         prepared = await session.create_prepared(statement_str)
         statement_ = prepared.bind()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,38 @@
+from acsylla import (
+    Cluster,
+    create_cluster,
+    create_statement,
+    PreparedStatement,
+    Result,
+    Row,
+    Session,
+    Statement,
+    Value,
+)
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_types(host, keyspace, id_generation):
+    id_ = next(id_generation)
+    value = id_
+
+    cluster: Cluster = create_cluster([host])
+    session: Session = await cluster.create_session(keyspace=keyspace)
+    statement: Statement = create_statement("INSERT INTO test (id, value) values(" + str(id_) + ", " + str(value) + ")")
+    await session.execute(statement)
+
+    # read the new inserted value
+    prepared: PreparedStatement = await session.create_prepared("SELECT id, value FROM test WHERE id = ?")
+    statement: Statement = prepared.bind()
+    statement.bind_int_by_name("id", id_)
+    result: Result = await session.execute(statement)
+
+    _: int = result.count()
+    _: int = result.column_count()
+
+    row: Row = result.first()
+    value: Value = row.column_by_name("id")
+    _: int = value.int()


### PR DESCRIPTION
With this PR all Cython classes are described as Python interfaces
allowing the user to know what methods each instance class has.

Also from now on any factory would need to be done through the Python
land that provides a way for closing the loop in terms of documentation
and typing, for example, consider the following snippet:

```python
    from acsylla import create_cluster, Cluster

    def my_cluster(self, hosts) -> Cluster:
        return create_cluster(hosts)
```

All interfaces are exposed as first citizen classes that the user can
use for typing and for getting documentation.

When an existing function/coroutine that was already there, and got
documented because of the addition of the interfaces, like for example
the coroutine `cluster.create_session()` has not been isolated as a
separated factory since there is an explicit method that already provides
the documentation.

Closes https://github.com/pfreixes/acsylla/issues/4