### PR TITLE
Add support for retrieveing basic type column values

### DIFF
--- a/acsylla/_cython/cpp_cassandra.pxi
+++ b/acsylla/_cython/cpp_cassandra.pxi
@@ -113,6 +113,11 @@ cdef extern from "cassandra.h":
   const CassValue* cass_row_get_column_by_name(const CassRow* row, const char* name)
 
   CassError cass_value_get_int32(const CassValue* value, cass_int32_t * output)
+  CassError cass_value_get_float(const CassValue* value, cass_float_t* output)
+  CassError cass_value_get_bool(const CassValue* value, cass_bool_t* output)
+  CassError cass_value_get_string(const CassValue* value, const char** output, size_t* output_size)
+  CassError cass_value_get_bytes(const CassValue* value, const cass_byte_t** output, size_t* output_size);
+
 
   CassRow* cass_iterator_get_row(const CassIterator* iterator)
   cass_bool_t cass_iterator_next(CassIterator* iterator)

--- a/acsylla/_cython/result/value.pyx
+++ b/acsylla/_cython/result/value.pyx
@@ -61,19 +61,18 @@ cdef class Value:
 
         Raises a `ColumnValueError` if the value can not be retrieved"""
         cdef Py_ssize_t length = 0
-        cdef const char* output
+        cdef char* output = NULL
         cdef CassError error
         cdef bytes string
 
-        error = cass_value_get_string(self.cass_value, &output, <size_t*> &length)
+        error = cass_value_get_string(self.cass_value,<const char**> &output, <size_t*> &length)
         if error != CASS_OK:
             raise ColumnValueError()
 
-        try:
-            string = output[:length]
-        finally:
-            free(<void*>output)
-
+        # This pointer does not need to be free up since its an
+        # slice of the buffer kept by the Cassandra driver and related to
+        # the result. When the result is free up all the space will be free up.
+        string = output[:length]
         return string.decode()
             
     def bytes(self):
@@ -81,17 +80,16 @@ cdef class Value:
 
         Raises a `ColumnValueError` if the value can not be retrieved"""
         cdef Py_ssize_t length = 0
-        cdef const cass_byte_t* output
+        cdef cass_byte_t* output = NULL
         cdef CassError error
         cdef bytes bytes_
 
-        error = cass_value_get_bytes(self.cass_value, &output, <size_t*> &length)
+        error = cass_value_get_bytes(self.cass_value, <const cass_byte_t**> &output, <size_t*> &length)
         if error != CASS_OK:
             raise ColumnValueError()
 
-        try:
-            bytes_ = output[:length]
-        finally:
-            free(<void*>output)
- 
+        # This pointer does not need to be free up since its an
+        # slice of the buffer kept by the Cassandra driver and related to
+        # the result. When the result is free up all the space will be free up.
+        bytes_ = output[:length]
         return bytes_

--- a/acsylla/_cython/result/value.pyx
+++ b/acsylla/_cython/result/value.pyx
@@ -1,3 +1,6 @@
+from libc.stdlib cimport free
+
+
 cdef class Value:
 
     def __cinit__(self):
@@ -12,7 +15,7 @@ cdef class Value:
         return value
 
     def int(self):
-        """ Returns the int value of a columnt.
+        """ Returns the int value of a column.
 
         Raises a `ColumnValueError` if the value can not be retrieved"""
         cdef int output
@@ -23,3 +26,72 @@ cdef class Value:
             raise ColumnValueError()
 
         return output
+
+    def float(self):
+        """ Returns the float value of a column.
+
+        Raises a `ColumnValueError` if the value can not be retrieved"""
+        cdef float output
+        cdef CassError error
+
+        error = cass_value_get_float(self.cass_value, <cass_float_t*> &output)
+        if error != CASS_OK:
+            raise ColumnValueError()
+
+        return output
+
+    def bool(self):
+        """ Returns the bool value of a column.
+
+        Raises a `ColumnValueError` if the value can not be retrieved"""
+        cdef cass_bool_t output
+        cdef CassError error
+
+        error = cass_value_get_bool(self.cass_value, <cass_bool_t*> &output)
+        if error != CASS_OK:
+            raise ColumnValueError()
+
+        if output == cass_true:
+            return True
+        else:
+            return False
+
+    def string(self):
+        """ Returns the string value of a column.
+
+        Raises a `ColumnValueError` if the value can not be retrieved"""
+        cdef Py_ssize_t length = 0
+        cdef const char* output
+        cdef CassError error
+        cdef bytes string
+
+        error = cass_value_get_string(self.cass_value, &output, <size_t*> &length)
+        if error != CASS_OK:
+            raise ColumnValueError()
+
+        try:
+            string = output[:length]
+        except:
+            free(<void*>output)
+
+        return string.decode()
+            
+    def bytes(self):
+        """ Returns the bytes value of a column.
+
+        Raises a `ColumnValueError` if the value can not be retrieved"""
+        cdef Py_ssize_t length = 0
+        cdef const cass_byte_t* output
+        cdef CassError error
+        cdef bytes bytes_
+
+        error = cass_value_get_bytes(self.cass_value, &output, <size_t*> &length)
+        if error != CASS_OK:
+            raise ColumnValueError()
+
+        try:
+            bytes_ = output[:length]
+        except:
+            free(<void*>output)
+ 
+        return bytes_

--- a/acsylla/_cython/result/value.pyx
+++ b/acsylla/_cython/result/value.pyx
@@ -71,7 +71,7 @@ cdef class Value:
 
         try:
             string = output[:length]
-        except:
+        finally:
             free(<void*>output)
 
         return string.decode()
@@ -91,7 +91,7 @@ cdef class Value:
 
         try:
             bytes_ = output[:length]
-        except:
+        finally:
             free(<void*>output)
  
         return bytes_

--- a/acsylla/base.py
+++ b/acsylla/base.py
@@ -163,3 +163,19 @@ class Value(metaclass=ABCMeta):
     @abstractmethod
     def int(self) -> int:
         """ Returns the int value associated to a column."""
+
+    @abstractmethod
+    def bool(self) -> bool:
+        """ Returns the bool value associated to a column."""
+
+    @abstractmethod
+    def float(self) -> float:
+        """ Returns the float value associated to a column."""
+
+    @abstractmethod
+    def string(self) -> str:
+        """ Returns the string value associated to a column."""
+
+    @abstractmethod
+    def bytes(self) -> bytes:
+        """ Returns the bytes value associated to a column."""

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -126,9 +126,5 @@ class TestResult:
         assert values_returned == []
 
     @pytest.mark.xfail
-    async def test_result_types_supported(self, session, id_generation):
-        raise Exception("TODO")
-
-    @pytest.mark.xfail
     async def test_result_more_pages(self, session, id_generation):
         raise Exception("TODO")

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -1,0 +1,91 @@
+from acsylla import create_statement
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestValue:
+    async def test_int(self, session, id_generation):
+        id_ = next(id_generation)
+        value = 100
+
+        insert_statement = create_statement("INSERT INTO test (id, value_int) values (?, ?)", parameters=2)
+        insert_statement.bind_int(0, id_)
+        insert_statement.bind_int(1, value)
+        await session.execute(insert_statement)
+
+        select_statement = create_statement("SELECT value_int FROM test WHERE ( id = ? )", parameters=1)
+        select_statement.bind_int(0, id_)
+        result = await session.execute(select_statement)
+
+        row = result.first()
+
+        assert row.column_by_name("value_int").int() == value
+
+    async def test_float(self, session, id_generation):
+        id_ = next(id_generation)
+        value = 100.0
+
+        insert_statement = create_statement("INSERT INTO test (id, value_float) values (?, ?)", parameters=2)
+        insert_statement.bind_int(0, id_)
+        insert_statement.bind_float(1, value)
+        await session.execute(insert_statement)
+
+        select_statement = create_statement("SELECT value_float FROM test WHERE ( id = ? )", parameters=1)
+        select_statement.bind_int(0, id_)
+        result = await session.execute(select_statement)
+
+        row = result.first()
+
+        assert row.column_by_name("value_float").float() == value
+
+    async def test_bool(self, session, id_generation):
+        id_ = next(id_generation)
+        value = True
+
+        insert_statement = create_statement("INSERT INTO test (id, value_bool) values (?, ?)", parameters=2)
+        insert_statement.bind_int(0, id_)
+        insert_statement.bind_bool(1, value)
+        await session.execute(insert_statement)
+
+        select_statement = create_statement("SELECT value_bool FROM test WHERE ( id = ? )", parameters=1)
+        select_statement.bind_int(0, id_)
+        result = await session.execute(select_statement)
+
+        row = result.first()
+
+        assert row.column_by_name("value_bool").bool() == value
+
+    async def test_string(self, session, id_generation):
+        id_ = next(id_generation)
+        value = "acsylla"
+
+        insert_statement = create_statement("INSERT INTO test (id, value_text) values (?, ?)", parameters=2)
+        insert_statement.bind_int(0, id_)
+        insert_statement.bind_string(1, value)
+        await session.execute(insert_statement)
+
+        select_statement = create_statement("SELECT value_text FROM test WHERE ( id = ? )", parameters=1)
+        select_statement.bind_int(0, id_)
+        result = await session.execute(select_statement)
+
+        row = result.first()
+
+        assert row.column_by_name("value_text").string() == value
+
+    async def test_bytes(self, session, id_generation):
+        id_ = next(id_generation)
+        value = b"acsylla"
+
+        insert_statement = create_statement("INSERT INTO test (id, value_blob) values (?, ?)", parameters=2)
+        insert_statement.bind_int(0, id_)
+        insert_statement.bind_bytes(1, value)
+        await session.execute(insert_statement)
+
+        select_statement = create_statement("SELECT value_blob FROM test WHERE ( id = ? )", parameters=1)
+        select_statement.bind_int(0, id_)
+        result = await session.execute(select_statement)
+        row = result.first()
+
+        assert row.column_by_name("value_blob").bytes() == value


### PR DESCRIPTION
Acsylla supports now setting and retrieving the following column value
formats: `int`, `bool`, `float`, `string`, and `bytes`

Closes this https://github.com/pfreixes/acsylla/issues/19