### PR TITLE
Add support for fething results in a paginated way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+NOT RELEASED YET
+=======
+- Support for paging. Now we can set the page size of the statements - preared or not prepared - and later on
+provide a token for fethcing the next page
+
 0.1.0a0
 =======
 Alpha release for getting feedback from the comunity, the driver is not yet production ready but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 NOT RELEASED YET
 =======
 - Support for paging. Now we can set the page size of the statements - preared or not prepared - and later on
-provide a token for fethcing the next page
+provide a token for fethcing the next page [#30](https://github.com/pfreixes/acsylla/pull/30)
 
 0.1.0a0
 =======

--- a/acsylla/_cython/cpp_cassandra.pxi
+++ b/acsylla/_cython/cpp_cassandra.pxi
@@ -90,6 +90,8 @@ cdef extern from "cassandra.h":
   CassError cass_statement_bind_float_by_name_n(CassStatement* statement, const char* name, size_t name_length, cass_float_t value);
   CassError cass_statement_bind_int32_by_name_n(CassStatement* statement, const char* name, size_t name_length, cass_int32_t value);
   CassError cass_statement_bind_null_by_name_n(CassStatement* statement, const char* name, size_t name_length);
+  CassError cass_statement_set_paging_size(CassStatement* statement, int page_size);
+  CassError cass_statement_set_paging_state_token(CassStatement* statement, const char* paging_state, size_t paging_state_size);
 
 
   void cass_statement_free(CassStatement* statement)
@@ -108,6 +110,8 @@ cdef extern from "cassandra.h":
   size_t cass_result_column_count(CassResult* result)
   CassRow* cass_result_first_row(CassResult* result)
   CassIterator* cass_iterator_from_result(const CassResult* result)
+  cass_bool_t cass_result_has_more_pages(const CassResult* result)
+  CassError cass_result_paging_state_token(const CassResult* result, const char** paging_state, size_t* paging_state_size);
   void cass_result_free(CassResult* result)
 
   const CassValue* cass_row_get_column_by_name(const CassRow* row, const char* name)

--- a/acsylla/_cython/statement/prepared.pyx
+++ b/acsylla/_cython/statement/prepared.pyx
@@ -14,10 +14,10 @@ cdef class PreparedStatement:
         prepared.cass_prepared = cass_prepared
         return prepared
 
-    def bind(self):
+    def bind(self, object page_size=None, object page_state=None):
         cdef CassStatement* cass_statement
         cdef Statement statement
 
         cass_statement = cass_prepared_bind(self.cass_prepared)
-        statement = Statement.new_from_prepared(cass_statement)
+        statement = Statement.new_from_prepared(cass_statement, page_size, page_state)
         return statement

--- a/acsylla/_cython/statement/statement.pxd
+++ b/acsylla/_cython/statement/statement.pxd
@@ -4,10 +4,11 @@ cdef class Statement:
         CassStatement* cass_statement
 
     @staticmethod
-    cdef Statement new_from_string(str statement_str, int parameters)
+    cdef Statement new_from_string(str statement_str, int parameters, object page_size, object page_state)
 
     @staticmethod
-    cdef Statement new_from_prepared(CassStatement* cass_statement)
+    cdef Statement new_from_prepared(CassStatement* cass_statement, object page_size, object page_state)
 
+    cdef _set_paging(self, object py_page_size, object py_page_state)
     cdef _check_bind_error_or_raise(self, CassError error)
     cdef _check_if_prepared_or_raise(self)

--- a/acsylla/base.py
+++ b/acsylla/base.py
@@ -109,7 +109,7 @@ class PreparedStatement(metaclass=ABCMeta):
     `session.create_prepared()` coroutine for creating a new instance"""
 
     @abstractmethod
-    def bind(self) -> Statement:
+    def bind(self, page_size: Optional[int] = None, page_state: Optional[bytes] = None) -> Statement:
         """ Returns a new statment using the prepared."""
 
 
@@ -148,6 +148,21 @@ class Result(metaclass=ABCMeta):
         iterator.
 
         If there is no rows iterator returns no rows.
+        """
+
+    @abstractmethod
+    def has_more_pages(self) -> bool:
+        """ Returns true if there is still pages to be fetched"""
+
+    @abstractmethod
+    def page_state(self) -> bytes:
+        """ Returns a token with the page state for continuing fetching
+        new results.
+
+        Before calling this method you must first checks if there are more
+        results using the `has_more_pages` function, and if there are use the
+        token returned by this function as an argument of the factories for creating
+        an statement for returning the next page.
         """
 
 

--- a/acsylla/factories.py
+++ b/acsylla/factories.py
@@ -1,14 +1,18 @@
 from . import _cython
 from .base import Batch, Cluster, Statement
-from typing import List
+from typing import List, Optional
 
 
 def create_cluster(contact_points: List[str], protocol_version: int = 3) -> Cluster:
     return _cython.cyacsylla.Cluster(contact_points, protocol_version=protocol_version)
 
 
-def create_statement(statement: str, parameters: int = 0) -> Statement:
-    return _cython.cyacsylla.create_statement(statement, parameters=parameters)
+def create_statement(
+    statement: str, parameters: int = 0, page_size: Optional[int] = None, page_state: Optional[bytes] = None
+) -> Statement:
+    return _cython.cyacsylla.create_statement(
+        statement, parameters=parameters, page_size=page_size, page_state=page_state
+    )
 
 
 def create_batch_logged() -> Batch:

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -7,14 +7,16 @@ pytestmark = pytest.mark.asyncio
 
 
 class TestResult:
-    async def _build_statement(self, session, type_, statement_str, parameters):
+    async def _build_statement(self, session, type_, statement_str, parameters, page_size=None, page_state=None):
         if type_ == "none_prepared":
-            statement_ = create_statement(statement_str, parameters=parameters)
+            statement_ = create_statement(
+                statement_str, parameters=parameters, page_size=page_size, page_state=page_state
+            )
         elif type_ == "prepared":
             prepared = await session.create_prepared(statement_str)
-            statement_ = prepared.bind()
+            statement_ = prepared.bind(page_size=page_size, page_state=page_state)
         else:
-            raise ValueError()
+            raise ValueError(type_)
         return statement_
 
     @pytest.fixture(params=["none_prepared", "prepared"])
@@ -125,6 +127,52 @@ class TestResult:
         assert ids_returned == []
         assert values_returned == []
 
-    @pytest.mark.xfail
-    async def test_result_more_pages(self, session, id_generation):
-        raise Exception("TODO")
+    @pytest.mark.parametrize(
+        "page_size,pages_fetched_expected",
+        [
+            # Check that when page size is disabled, only one page is fetched
+            (None, 1),
+            # When number of results returned do not match with the page size,
+            # pages returned are optimal
+            (75, 2),
+            # When number of results returned match with the page size driver
+            # forces us to make a new fetch returning the last one zero results
+            (100, 2),
+            (25, 5),
+            (50, 3),
+        ],
+    )
+    @pytest.mark.parametrize("type_", ["prepared", "none_prepared"])
+    async def test_result_paging(self, session, id_generation, type_, page_size, pages_fetched_expected):
+        total_rows = 100
+        value = 33
+        insert_statement = "INSERT INTO test (id, value) values(?, ?)"
+        select_statement = "SELECT id, value FROM test WHERE id >= :min and id <= :max ALLOW FILTERING"
+
+        statement = create_statement(insert_statement, parameters=2)
+        statement.bind_int(1, value)
+        ids = [next(id_generation) for i in range(total_rows)]
+        # write results
+        for id_ in ids:
+            statement.bind_int(0, id_)
+            await session.execute(statement)
+
+        # read all results using pagination
+        page_state = None
+        pages_fetched = 0
+        while True:
+            statement = await self._build_statement(
+                session, type_, select_statement, 2, page_size=page_size, page_state=page_state
+            )
+            statement.bind_int(0, ids[0])
+            statement.bind_int(1, ids[-1])
+            result = await session.execute(statement)
+
+            pages_fetched += 1
+
+            if not result.has_more_pages():
+                break
+
+            page_state = result.page_state()
+
+        assert pages_fetched == pages_fetched_expected


### PR DESCRIPTION
PR provides support for tunning the page size for prepared and none
prepared statements.

Once this page size is configured, by default disabled, we can set
the page token state for fetching the next page.

Is the responsibility of the caller of aksing if there are more pages and
if there are set the token and repeat the operation until there is no
more pages to be fetched.

Cassandra might return a very last page with empty results when the page size is
equal to the number of results returned in the previous call.

Example of how paging can be used here [1]

Closes this https://github.com/pfreixes/acsylla/issues/15

[1] https://github.com/pfreixes/acsylla/pull/30/files#diff-761c07fa86cf8b3d46e3681453e2698cR146