### PR TITLE
Add support for timeout configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ NOT RELEASED YET
 =======
 - Expose the c++ library error definitions as python exceptions
 - UUID: bindings and value method.
+- Add support for configuring a timeout during cluster, statement, prepared and batch creation time. Timeouts
+are expressed in seconds.
 
 0.1.2a0
 =======

--- a/acsylla/_cython/cluster/cluster.pyx
+++ b/acsylla/_cython/cluster/cluster.pyx
@@ -12,11 +12,21 @@ cdef class Cluster:
     def __dealloc__(self):
         cass_cluster_free(self.cass_cluster)
 
-    def __init__(self, list contact_points, protocol_version=3):
+    def __init__(
+        self,
+        list contact_points,
+        int protocol_version,
+        float connect_timeout,
+        float request_timeout,
+        float resolve_timeout):
+
         cdef CassProtocolVersion cass_protocol_version
         cdef str contact_points_csv
         cdef bytes contact_points_csv_b
         cdef CassError error
+        cdef int connect_timeout_ms = int(connect_timeout * 1000)
+        cdef int request_timeout_ms = int(request_timeout * 1000)
+        cdef int resolve_timeout_ms = int(resolve_timeout * 1000)
 
         if not contact_points:
             raise ValueError("Contact points can not be an empty list or a None value")
@@ -47,6 +57,10 @@ cdef class Cluster:
         error = cass_cluster_set_protocol_version(self.cass_cluster, cass_protocol_version)
         if error != CASS_OK:
             raise RuntimeError(error)
+
+        cass_cluster_set_connect_timeout(self.cass_cluster, connect_timeout_ms)
+        cass_cluster_set_request_timeout(self.cass_cluster, request_timeout_ms)
+        cass_cluster_set_resolve_timeout(self.cass_cluster, resolve_timeout_ms)
 
     async def create_session(self, keyspace=None):
         session = Session(self, keyspace=keyspace)

--- a/acsylla/_cython/cpp_cassandra.pxi
+++ b/acsylla/_cython/cpp_cassandra.pxi
@@ -130,6 +130,9 @@ cdef extern from "cassandra.h":
   void cass_cluster_free(CassCluster* cluster)
   CassError cass_cluster_set_contact_points_n(CassCluster* cluster, const char* contact_points, size_t contat_points_length)
   CassError cass_cluster_set_protocol_version(CassCluster* cluster, int protocol_version)
+  void cass_cluster_set_connect_timeout(CassCluster* cluster, unsigned timeout_ms)
+  void cass_cluster_set_request_timeout(CassCluster* cluster, unsigned timeout_ms)
+  void cass_cluster_set_resolve_timeout(CassCluster* cluster, unsigned timeout_ms)
 
 
   CassSession* cass_session_new()
@@ -142,6 +145,7 @@ cdef extern from "cassandra.h":
   CassFuture* cass_session_close(CassSession* session)
 
   CassStatement* cass_statement_new_n(const char* query, size_t query_length, size_t parameter_count)
+  CassError cass_statement_set_request_timeout(CassStatement* statement, cass_uint64_t timeout_ms)
   CassError cass_statement_bind_null(CassStatement* statement, size_t index)
   CassError cass_statement_bind_int32(CassStatement* statement, size_t index, cass_int32_t value)
   CassError cass_statement_bind_float(CassStatement* statement, size_t index, cass_float_t value)
@@ -199,6 +203,7 @@ cdef extern from "cassandra.h":
 
   CassBatch* cass_batch_new(CassBatchType type)
   CassError cass_batch_add_statement(CassBatch* batch, CassStatement* statement)
+  CassError cass_batch_set_request_timeout(CassBatch* batch, cass_uint64_t timeout_ms)
   void cass_batch_free(CassBatch* cass_batch)
 
   CassError cass_uuid_from_string(const char* str, CassUuid* output)

--- a/acsylla/_cython/session/session.pyx
+++ b/acsylla/_cython/session/session.pyx
@@ -97,7 +97,7 @@ cdef class Session:
 
         return result
 
-    async def create_prepared(self, str statement):
+    async def create_prepared(self, str statement, object timeout=None):
         """ Prepares an statement."""
         cdef CassFuture* cass_future
         cdef CassError cass_error
@@ -122,7 +122,7 @@ cdef class Session:
                 cass_error = cass_future_error_code(cass_future)
                 raise_if_error(cass_error)
 
-            prepared = PreparedStatement.new_(cass_prepared)
+            prepared = PreparedStatement.new_(cass_prepared, timeout)
         finally:
             cass_future_free(cass_future)
 

--- a/acsylla/_cython/statement/batch.pxd
+++ b/acsylla/_cython/statement/batch.pxd
@@ -3,4 +3,4 @@ cdef class Batch:
         CassBatch* cass_batch
 
     @staticmethod
-    cdef Batch new_(CassBatchType type_)
+    cdef Batch new_(CassBatchType type_, object timeout)

--- a/acsylla/_cython/statement/batch.pyx
+++ b/acsylla/_cython/statement/batch.pyx
@@ -7,11 +7,20 @@ cdef class Batch:
         cass_batch_free(self.cass_batch)
 
     @staticmethod
-    cdef Batch new_(CassBatchType type_):
+    cdef Batch new_(CassBatchType type_, object timeout):
+        cdef CassError error
         cdef Batch batch
+        cdef int timeout_ms
 
         batch = Batch()
         batch.cass_batch = cass_batch_new(type_)
+
+        if timeout is not None:
+            timeout_ms = int(timeout * 1000)
+            error = cass_batch_set_request_timeout(batch.cass_batch, timeout_ms)
+            if error != CASS_OK:
+                raise CassException(error)
+
         return batch
 
     def add_statement(self, Statement statement):
@@ -22,13 +31,13 @@ cdef class Batch:
             raise CassException(error)
 
 
-def create_batch_logged():
+def create_batch_logged(timeout=None):
     cdef Batch batch
-    batch = Batch.new_(CASS_BATCH_TYPE_LOGGED)
+    batch = Batch.new_(CASS_BATCH_TYPE_LOGGED, timeout)
     return batch
 
 
-def create_batch_unlogged():
+def create_batch_unlogged(timeout=None):
     cdef Batch batch
-    batch = Batch.new_(CASS_BATCH_TYPE_UNLOGGED)
+    batch = Batch.new_(CASS_BATCH_TYPE_UNLOGGED, timeout)
     return batch

--- a/acsylla/_cython/statement/prepared.pxd
+++ b/acsylla/_cython/statement/prepared.pxd
@@ -1,6 +1,7 @@
 cdef class PreparedStatement:
     cdef:
         const CassPrepared* cass_prepared
+        object timeout
 
     @staticmethod
-    cdef PreparedStatement new_(const CassPrepared* cass_prepared)
+    cdef PreparedStatement new_(const CassPrepared* cass_prepared, object timeout)

--- a/acsylla/_cython/statement/prepared.pyx
+++ b/acsylla/_cython/statement/prepared.pyx
@@ -7,11 +7,12 @@ cdef class PreparedStatement:
         cass_prepared_free(self.cass_prepared)
 
     @staticmethod
-    cdef PreparedStatement new_(const CassPrepared* cass_prepared):
+    cdef PreparedStatement new_(const CassPrepared* cass_prepared, object timeout):
         cdef PreparedStatement prepared
 
         prepared = PreparedStatement()
         prepared.cass_prepared = cass_prepared
+        prepared.timeout = timeout
         return prepared
 
     def bind(self, object page_size=None, object page_state=None):
@@ -19,5 +20,5 @@ cdef class PreparedStatement:
         cdef Statement statement
 
         cass_statement = cass_prepared_bind(self.cass_prepared)
-        statement = Statement.new_from_prepared(cass_statement, page_size, page_state)
+        statement = Statement.new_from_prepared(cass_statement, page_size, page_state, self.timeout)
         return statement

--- a/acsylla/_cython/statement/statement.pxd
+++ b/acsylla/_cython/statement/statement.pxd
@@ -4,11 +4,12 @@ cdef class Statement:
         CassStatement* cass_statement
 
     @staticmethod
-    cdef Statement new_from_string(str statement_str, int parameters, object page_size, object page_state)
+    cdef Statement new_from_string(str statement_str, int parameters, object page_size, object page_state, object timeout)
 
     @staticmethod
-    cdef Statement new_from_prepared(CassStatement* cass_statement, object page_size, object page_state)
+    cdef Statement new_from_prepared(CassStatement* cass_statement, object page_size, object page_state, object timeout)
 
     cdef _set_paging(self, object py_page_size, object py_page_state)
+    cdef _set_timeout(self, object timeout)
     cdef _check_bind_error_or_raise(self, CassError error)
     cdef _check_if_prepared_or_raise(self)

--- a/acsylla/base.py
+++ b/acsylla/base.py
@@ -1,16 +1,12 @@
 """Abstract base classes, use them for documentation or for adding
 types in your functions."""
 from abc import ABCMeta, abstractmethod
-from typing import Iterable, List, Optional
+from typing import Iterable, Optional
 
 
 class Cluster(metaclass=ABCMeta):
     """Provides a Cluster instance class. Use the factory `create_cluster`
     for creating a new instance"""
-
-    @abstractmethod
-    def __init__(self, contact_points: List[str], protocol_version: int = 3):
-        ...
 
     @abstractmethod
     async def create_session(self, keyspace: Optional[str] = None) -> "Session":
@@ -40,8 +36,12 @@ class Session(metaclass=ABCMeta):
         """ Executes an statement and returns the result."""
 
     @abstractmethod
-    async def create_prepared(self, statement: str) -> "PreparedStatement":
-        """ Prepares an statement."""
+    async def create_prepared(self, statement: str, timeout: Optional[float] = None) -> "PreparedStatement":
+        """ Prepares an statement.
+
+        By providing a `timeout` all requests built by the prepared statement will use it,
+        otherwise timeout provided during the Cluster instantantation will be used. Value expected is seconds.
+        """
 
     @abstractmethod
     async def execute_batch(self, batch: "Batch") -> None:

--- a/acsylla/factories.py
+++ b/acsylla/factories.py
@@ -3,21 +3,69 @@ from .base import Batch, Cluster, Statement
 from typing import List, Optional
 
 
-def create_cluster(contact_points: List[str], protocol_version: int = 3) -> Cluster:
-    return _cython.cyacsylla.Cluster(contact_points, protocol_version=protocol_version)
+def create_cluster(
+    contact_points: List[str],
+    protocol_version: int = 3,
+    connect_timeout: float = 5.0,
+    request_timeout: float = 2.0,
+    resolve_timeout: float = 1.0,
+) -> Cluster:
+    """Instanciates a new cluster.
 
+    Provide a list of `contact_points` for using them as a first list of cluster nodes for using
+    them as a first list of contacting nodes.
 
-def create_statement(
-    statement: str, parameters: int = 0, page_size: Optional[int] = None, page_state: Optional[bytes] = None
-) -> Statement:
-    return _cython.cyacsylla.create_statement(
-        statement, parameters=parameters, page_size=page_size, page_state=page_state
+    By default `protocol_version` 3 is used, if you want to specify another protocol version
+    you must provide a different value.
+
+    If `connect_timeout`, `request_timeout` or `resolve_timeout` are provided they will
+    override the default values. Values provided are in seconds.
+    """
+    return _cython.cyacsylla.Cluster(
+        contact_points, protocol_version, connect_timeout, request_timeout, resolve_timeout,
     )
 
 
-def create_batch_logged() -> Batch:
-    return _cython.cyacsylla.create_batch_logged()
+def create_statement(
+    statement: str,
+    parameters: int = 0,
+    page_size: Optional[int] = None,
+    page_state: Optional[bytes] = None,
+    timeout: Optional[float] = None,
+) -> Statement:
+    """
+    Creates a new statment.
+
+    Provide a raw `statement` and the number of `parameters` if there are, othewise will default to
+    0.
+
+    Pagination can be handled by providing a `page_size` for telling the maximum size of records
+    fetched. The `page_state` will act as a cursor by returning the next results of a previous
+    execution.
+
+    If `timeout` is provided, this will override the request timeout provided during the cluster
+    creation. Value expected is in seconds.
+    """
+    return _cython.cyacsylla.create_statement(
+        statement, parameters=parameters, page_size=page_size, page_state=page_state, timeout=timeout
+    )
 
 
-def create_batch_unlogged() -> Batch:
-    return _cython.cyacsylla.create_batch_logged()
+def create_batch_logged(timeout: Optional[float] = None) -> Batch:
+    """
+    Creates a new batch logged.
+
+    If `timeout` is provided, this will override the request timeout provided during the cluster
+    creation. Value expected is in seconds.
+    """
+    return _cython.cyacsylla.create_batch_logged(timeout)
+
+
+def create_batch_unlogged(timeout: Optional[float] = None) -> Batch:
+    """
+    Creates a new batch unlogged.
+
+    If `timeout` is provided, this will override the request timeout provided during the cluster
+    creation. Value expected is in seconds.
+    """
+    return _cython.cyacsylla.create_batch_logged(timeout)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def host():
 
 @pytest.fixture
 async def cluster(event_loop, host):
-    return create_cluster([host], connect_timeout=1.0, request_timeout=1.0, resolve_timeout=1.0)
+    return create_cluster([host], connect_timeout=2.0, request_timeout=2.0, resolve_timeout=2.0)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def host():
 
 @pytest.fixture
 async def cluster(event_loop, host):
-    return create_cluster([host])
+    return create_cluster([host], connect_timeout=0.1, request_timeout=0.1, resolve_timeout=0.1)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def host():
 
 @pytest.fixture
 async def cluster(event_loop, host):
-    return create_cluster([host], connect_timeout=0.1, request_timeout=0.1, resolve_timeout=0.1)
+    return create_cluster([host], connect_timeout=1.0, request_timeout=1.0, resolve_timeout=1.0)
 
 
 @pytest.fixture

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -36,6 +36,14 @@ class TestBatch:
         batch = create_batch_unlogged()
         assert batch is not None
 
+    def test_create_batch_logged_with_timeout(self):
+        batch = create_batch_logged(timeout=1.0)
+        assert batch is not None
+
+    def test_create_batch_unlogged_with_timeout(self):
+        batch = create_batch_unlogged(timeout=1.0)
+        assert batch is not None
+
     def test_add_statement(self, batch, statement):
         # just check that does not raise any error
         batch.add_statement(statement)

--- a/tests/test_prepared.py
+++ b/tests/test_prepared.py
@@ -4,6 +4,11 @@ pytestmark = pytest.mark.asyncio
 
 
 class TestPreparedStatement:
+    async def test_create_with_timeout(self, session):
+        statement_str = "INSERT INTO test (id, value) values( ?, ?)"
+        prepared = await session.create_prepared(statement_str, timeout=1.0)
+        assert prepared is not None
+
     async def test_bind(self, session):
         statement_str = "INSERT INTO test (id, value) values( ?, ?)"
         prepared = await session.create_prepared(statement_str)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -22,7 +22,7 @@ class TestSession:
         await session.close()
 
     async def test_create_session_invalid_host(self, keyspace):
-        cluster = create_cluster(["1.0.0.0"])
+        cluster = create_cluster(["1.0.0.0"], connect_timeout=0.1)
         with pytest.raises(CassErrorLibNoHostsAvailable):
             await cluster.create_session(keyspace=keyspace)
 

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -25,6 +25,10 @@ class TestStatement:
 
         return statement_
 
+    def test_create_with_timeout(self):
+        statement = create_statement("INSERT INTO test (id) values (1)", timeout=1.0)
+        assert statement is not None
+
     def test_bind_null(self, statement):
         statement.bind_null(1)
 


### PR DESCRIPTION
Timeout configuration at available at the cluster, statement, create statement and
batch creation.

For cluster also connection time and resolve time are supported.

We use seconds instead of the milliseconds used behind the scenes by the CPP
driver. Also, default values have been configured to default values.

Addresses this https://github.com/pfreixes/acsylla/issues/9