### PR TITLE
Add support for retrieving Session metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ NOT RELEASED YET
 - UUID: bindings and value method.
 - Add support for configuring a timeout during cluster, statement, prepared and batch creation time. Timeouts
 are expressed in seconds.
+- Add support for returning metrics related to a Session. Returned metrics are latencies, rates and statistics.
 
 0.1.2a0
 =======

--- a/acsylla/__init__.py
+++ b/acsylla/__init__.py
@@ -6,6 +6,7 @@ from .base import (
     Result,
     Row,
     Session,
+    SessionMetrics,
     Statement,
     Value,
 )
@@ -25,6 +26,7 @@ __all__ = (
     "Result",
     "Row",
     "Value",
+    "SessionMetrics",
     "create_cluster",
     "create_statement",
     "create_batch_logged",

--- a/acsylla/_cython/cpp_cassandra.pxi
+++ b/acsylla/_cython/cpp_cassandra.pxi
@@ -2,6 +2,7 @@ ctypedef int cass_int32_t
 ctypedef float cass_float_t
 ctypedef unsigned char cass_byte_t
 ctypedef double cass_uint64_t
+ctypedef double cass_double_t
 
 
 cdef extern from "cassandra.h":
@@ -124,6 +125,38 @@ cdef extern from "cassandra.h":
   ctypedef struct CassUuid:
     pass
 
+  ctypedef struct _requests:
+    cass_uint64_t min
+    cass_uint64_t max
+    cass_uint64_t mean
+    cass_uint64_t stddev
+    cass_uint64_t median
+    cass_uint64_t percentile_75th
+    cass_uint64_t percentile_95th
+    cass_uint64_t percentile_98th
+    cass_uint64_t percentile_99th
+    cass_uint64_t percentile_999th
+    cass_double_t mean_rate
+    cass_double_t one_minute_rate
+    cass_double_t five_minute_rate
+    cass_double_t fifteen_minute_rate
+
+  ctypedef struct _stats:
+    cass_uint64_t total_connections
+    cass_uint64_t _deprecated_available_connections
+    cass_uint64_t _deprecated_exceeded_pending_requests_water_mark
+    cass_uint64_t _deprecated_exceeded_write_bytes_water_mark
+
+  ctypedef struct _errors:
+    cass_uint64_t connection_timeouts
+    cass_uint64_t _deprecated_pending_request_timeouts
+    cass_uint64_t request_timeouts
+
+  ctypedef struct CassMetrics:
+    _requests requests
+    _stats stats
+    _errors errors
+
   ctypedef void (*CassFutureCallback)(CassFuture* future, void* data)
 
   CassCluster* cass_cluster_new()
@@ -142,6 +175,9 @@ cdef extern from "cassandra.h":
   CassFuture* cass_session_execute(CassSession * session, const CassStatement* statement)
   CassFuture* cass_session_prepare_n(CassSession* session, const char* query, size_t query_length)
   CassFuture* cass_session_execute_batch(CassSession* session, const CassBatch* batch)
+  void cass_session_get_metrics(const CassSession* session, CassMetrics* output);
+
+
   CassFuture* cass_session_close(CassSession* session)
 
   CassStatement* cass_statement_new_n(const char* query, size_t query_length, size_t parameter_count)

--- a/acsylla/base.py
+++ b/acsylla/base.py
@@ -1,6 +1,7 @@
 """Abstract base classes, use them for documentation or for adding
 types in your functions."""
 from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
 from typing import Iterable, Optional
 
 
@@ -46,6 +47,10 @@ class Session(metaclass=ABCMeta):
     @abstractmethod
     async def execute_batch(self, batch: "Batch") -> None:
         """ Executes a batch of statements."""
+
+    @abstractmethod
+    async def metrics(self) -> "SessionMetrics":
+        """ Returns the metrics related to the session."""
 
 
 class Statement(metaclass=ABCMeta):
@@ -210,3 +215,34 @@ class Value(metaclass=ABCMeta):
     @abstractmethod
     def uuid(self) -> str:
         """ Returns the str value of the uuid associated to a column."""
+
+
+@dataclass
+class SessionMetrics:
+    """ Provides basic metrics for the Session."""
+
+    # requests time statistics in microseconds.
+    requests_min: int
+    requests_max: int
+    requests_mean: int
+    requests_stddev: int
+    requests_median: int
+    requests_percentile_75th: int
+    requests_percentile_95th: int
+    requests_percentile_98th: int
+    requests_percentile_99th: int
+    requests_percentile_999th: int
+
+    # requests rate, requests per second
+    requests_mean_rate: float
+    requests_one_minute_rate: float
+    requests_five_minute_rate: float
+    requests_fifteen_minute_rate: float
+
+    # Total connections available
+    stats_total_connections: int
+
+    # counters of timeouts at connection and
+    # request level
+    errors_connection_timeouts: int
+    errors_request_timeouts: int

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -71,3 +71,32 @@ class TestSession:
         await session.close()
         with pytest.raises(RuntimeError):
             await session.execute_batch(create_batch_unlogged())
+
+    async def test_metrics(self, session, id_generation):
+        # just for the sake of populate some metrics
+        key_and_value = str(next(id_generation))
+        statement = create_statement("INSERT INTO test (id, value) values(" + key_and_value + "," + key_and_value + ")")
+        await session.execute(statement)
+
+        metrics = session.metrics()
+
+        assert metrics.requests_min > 0
+        assert metrics.requests_max > 0
+        assert metrics.requests_mean > 0
+        assert metrics.requests_stddev > 0
+        assert metrics.requests_median > 0
+        assert metrics.requests_percentile_75th > 0
+        assert metrics.requests_percentile_95th > 0
+        assert metrics.requests_percentile_98th > 0
+        assert metrics.requests_percentile_99th > 0
+        assert metrics.requests_percentile_999th > 0
+        assert metrics.requests_mean_rate > 0.0
+
+        # TODO: driver reports 0.0, why?
+        # assert metrics.requests_five_minute_rate > 0.0
+        # assert metrics.requests_one_minute_rate > 0.0
+        # assert metrics.requests_fifteen_minute_rate > 0.0
+
+        assert metrics.stats_total_connections > 0
+        assert metrics.errors_connection_timeouts == 0
+        assert metrics.errors_request_timeouts == 0


### PR DESCRIPTION
Session metrics can be gathered by calling the `session.metrics()` method, which returns
metrics for latencies - different percentiles - rate of request - 1, 5 and 15 minutes aggregation - and
some generic counters and gauges for the total number of connections and timeouts.

Addresses https://github.com/pfreixes/acsylla/issues/8 